### PR TITLE
Adds a new adapter for complete data sets

### DIFF
--- a/src/Adapter/PreselectedPaginator.php
+++ b/src/Adapter/PreselectedPaginator.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-paginator for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-paginator/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-paginator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Paginator\Adapter;
+
+class PreselectedPaginator implements AdapterInterface
+{
+    /** @var iterable */
+    private $items;
+
+    /** @var int */
+    private $count;
+
+    public function __construct(iterable $items = [], int $count = 0)
+    {
+        $this->items = $items;
+        $this->count = $count;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItems($offset, $itemCountPerPage): iterable
+    {
+        return $this->items;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function count(): int
+    {
+        return $this->count;
+    }
+}

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -47,6 +47,8 @@ class AdapterPluginManager extends AbstractPluginManager
         'Array'          => Adapter\ArrayAdapter::class,
         'iterator'       => Adapter\Iterator::class,
         'Iterator'       => Adapter\Iterator::class,
+        'preselected'    => Adapter\PreselectedPaginator::class,
+        'Preselected'    => Adapter\PreselectedPaginator::class,
         'laminaspaginatoradapternull' => Adapter\NullFill::class,
 
         // Legacy Zend Framework aliases
@@ -73,12 +75,13 @@ class AdapterPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $factories = [
-        Adapter\Callback::class       => Adapter\Service\CallbackFactory::class,
-        Adapter\DbSelect::class       => Adapter\Service\DbSelectFactory::class,
-        Adapter\DbTableGateway::class => Adapter\Service\DbTableGatewayFactory::class,
-        Adapter\NullFill::class       => InvokableFactory::class,
-        Adapter\Iterator::class       => Adapter\Service\IteratorFactory::class,
-        Adapter\ArrayAdapter::class   => InvokableFactory::class,
+        Adapter\Callback::class             => Adapter\Service\CallbackFactory::class,
+        Adapter\DbSelect::class             => Adapter\Service\DbSelectFactory::class,
+        Adapter\DbTableGateway::class       => Adapter\Service\DbTableGatewayFactory::class,
+        Adapter\NullFill::class             => InvokableFactory::class,
+        Adapter\Iterator::class             => Adapter\Service\IteratorFactory::class,
+        Adapter\ArrayAdapter::class         => InvokableFactory::class,
+        Adapter\PreselectedPaginator::class => InvokableFactory::class,
 
         // v2 normalized names
 

--- a/test/Adapter/PreselectedAdapterTest.php
+++ b/test/Adapter/PreselectedAdapterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-paginator for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-paginator/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-paginator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Paginator\Adapter;
+
+use Laminas\Paginator\Adapter\PreselectedPaginator;
+use PHPUnit\Framework\TestCase;
+
+class PreselectedAdapterTest extends TestCase
+{
+    public function testAdapterCanBeCreatedWithoutParameters(): void
+    {
+        $adapter = new PreselectedPaginator();
+
+        self::assertSame(0, $adapter->count());
+        self::assertSame([], $adapter->getItems(1, 1));
+    }
+
+    /**
+     * @dataProvider parameterProvider
+     */
+    public function testCountMethodShouldReturnSameGivenValue(int $count): void
+    {
+        $adapter = new PreselectedPaginator([], $count);
+
+        self::assertSame($count, $adapter->count());
+    }
+
+    /**
+     * @dataProvider parameterProvider
+     */
+    public function testGetItemsMethodShouldReturnAlwaysSameResult(
+        int $offset,
+        int $itemCountPerPage
+    ): void {
+        $items   = range(1, 100);
+        $adapter = new PreselectedPaginator($items);
+
+        self::assertSame(
+            $items,
+            $adapter->getItems($offset, $itemCountPerPage)
+        );
+    }
+
+    public function parameterProvider(): array
+    {
+        return [
+            [
+                1,
+                1,
+            ],
+            [
+                10,
+                10,
+            ],
+            [
+                100,
+                100,
+            ],
+        ];
+    }
+}

--- a/test/AdapterPluginManagerTest.php
+++ b/test/AdapterPluginManagerTest.php
@@ -70,6 +70,8 @@ class AdapterPluginManagerTest extends TestCase
         $this->assertInstanceOf(Adapter\DbSelect::class, $plugin);
         $plugin = $this->adapterPluginManager->get('null', [ 101 ]);
         $this->assertInstanceOf(Adapter\NullFill::class, $plugin);
+        $plugin = $this->adapterPluginManager->get('preselected', [1, 2, 3]);
+        $this->assertInstanceOf(Adapter\PreselectedPaginator::class, $plugin);
 
         // Test dbtablegateway
         $mockStatement = $this->createMock(DbDriver\StatementInterface::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

The adapter uses all specified values as is, so that the paginator can also be used with complete / finished data sets.

### Example

The following example uses the object-relational manager [Atlas](http://atlasphp.io) and its [paging function](http://atlasphp.io/cassini/query/select.html#1-4-3-1-8) for selecting only the relevant entries:

```php
$select = $atlas->select(Album::class);
$select->perPage(15)->page(3); // uses limit and offset in the query

$paginator = new Laminas\Paginator\Paginator(
    new Laminas\Paginator\Adapter\PreselectedPaginator(
        $select->fetchRecordSet(), // returns 15 records as set
        $select->fetchCount() // returns the number of all entries, e.g. 100
    )
);
$paginator->setItemCountPerPage(15);
$paginator->setCurrentPageNumber(3);
```

