### PR TITLE
Add the ability to configure the adapter plugin manager

### DIFF
--- a/docs/book/advanced.md
+++ b/docs/book/advanced.md
@@ -1,12 +1,12 @@
 # Advanced usage
 
-## Using the paginator adapter plugin manager
+## Using the Paginator Adapter Plugin Manager
 
 laminas-paginator ships with a plugin manager for adapters, `Laminas\Paginator\AdapterPluginManager`.
 The plugin manager can be used to retrieve adapters.
 Since most adapters require constructor arguments, they may be passed as the second argument to the `get()` method in the same order they appear in the constructor.
 
-As examples:
+### Examples
 
 ```php
 use Laminas\Paginator\Adapter;
@@ -61,9 +61,9 @@ return array_slice($this->array, $offset, $itemCountPerPage);
 Take a look at the packaged adapters for ideas of how you might go about
 implementing your own.
 
-### Registering your adapter with the plugin manager
+### Registering Your Adapter with the Plugin Manager
 
-> - Since 2.10.0.
+> Available since version 2.10.0.
 
 If you want to register your adapter with the `Laminas\Pagiantor\AdapterPluginManager`, you can do so via configuration.
 The "paginators" configuration key can contain [standard laminas-servicemanager-style configuration](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/).

--- a/docs/book/advanced.md
+++ b/docs/book/advanced.md
@@ -1,5 +1,35 @@
 # Advanced usage
 
+## Using the paginator adapter plugin manager
+
+laminas-paginator ships with a plugin manager for adapters, `Laminas\Paginator\AdapterPluginManager`.
+The plugin manager can be used to retrieve adapters.
+Since most adapters require constructor arguments, they may be passed as the second argument to the `get()` method in the same order they appear in the constructor.
+
+As examples:
+
+```php
+use Laminas\Paginator\Adapter;
+use Laminas\Paginator\AdapterPluginManager;
+
+$pluginManager = new AdapterPluginManager();
+
+// Get an array adapter for an array of items
+$arrayAdapter = $pluginManager->get(Adapter\ArrayAdapter::class, [$arrayOfItems]);
+
+// Get a DbSelect adapter based on a Laminas\Db\Sql\Select instance and a DB adapter:
+$dbSelectAdapter = $pluginManager->get(Adapter\DbSelect::class, [
+    $select,
+    $dbAdapter
+]);
+
+// Get a DbTableGateway adapter based on a Laminas\Db\TableGateway\TableGateway instance:
+$dbTDGAdapter = $pluginManager->get(Adapter\DbTableGateway::class, [$tableGateway]);
+
+// Get an Iterator adapter based on an iterator:
+$iteratorAdapter = $pluginManager->get(Adapter\Iterator::class, [$iterator]);
+```
+
 ## Custom data source adapters
 
 At some point you may run across a data type that is not covered by the packaged
@@ -30,6 +60,45 @@ return array_slice($this->array, $offset, $itemCountPerPage);
 
 Take a look at the packaged adapters for ideas of how you might go about
 implementing your own.
+
+### Registering your adapter with the plugin manager
+
+> - Since 2.10.0.
+
+If you want to register your adapter with the `Laminas\Pagiantor\AdapterPluginManager`, you can do so via configuration.
+The "paginators" configuration key can contain [standard laminas-servicemanager-style configuration](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/).
+
+One possibility is to add it to the `config/autoload/global.php` file:
+
+```php
+return [
+    // ...
+    'paginators' => [
+        'factories' => [
+            YourCustomPaginationAdapter::class => YourCustomPaginationAdapterFactory::class,
+        ],
+    ],
+];
+```
+
+This allows you to retrieve the `AdapterPluginManager` in a factory, and then pull your adapter from it.
+As an example, consider the following factory:
+
+```php
+use Laminas\Paginator\AdapterPluginManager;
+use Laminas\Paginator\Paginator;
+use Psr\Container\ContainerInterface;
+
+class SomeServiceFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $paginators = $container->get(AdapterPluginManager::class);
+        $paginator  = new Paginator($paginators->get(YourCustomPaginatorAdapter::class));
+        // ...
+    }
+}
+```
 
 ## Custom scrolling styles
 

--- a/src/AdapterPluginManagerFactory.php
+++ b/src/AdapterPluginManagerFactory.php
@@ -9,6 +9,7 @@
 namespace Laminas\Paginator;
 
 use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Config;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
@@ -28,7 +29,24 @@ class AdapterPluginManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $name, array $options = null)
     {
-        return new AdapterPluginManager($container, $options ?: []);
+        $pluginManager = new AdapterPluginManager($container, $options ?: []);
+
+        // If we do not have a config service, nothing more to do
+        if (! $container->has('config')) {
+            return $pluginManager;
+        }
+
+        $config = $container->get('config')['paginators'] ?? null;
+
+        // If we do not have serializers configuration, nothing more to do
+        if (! is_array($config)) {
+            return $pluginManager;
+        }
+
+        // Wire service configuration for serializers
+        (new Config($config))->configureServiceManager($pluginManager);
+
+        return $pluginManager;
     }
 
     /**

--- a/test/AdapterPluginManagerFactoryTest.php
+++ b/test/AdapterPluginManagerFactoryTest.php
@@ -71,4 +71,67 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $adapters = $factory->createService($container->reveal());
         $this->assertSame($adapter, $adapters->get('test'));
     }
+
+    public function testDoesNotConfigureAdditionalPaginatorsWhenConfigServiceDoesNotContainPaginatorsConfig()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn(['foo' => 'bar']);
+
+        $factory = new AdapterPluginManagerFactory();
+        $adapters = $factory($container, AdapterPluginManager::class);
+
+        $this->assertInstanceOf(AdapterPluginManager::class, $adapters);
+        $this->assertFalse($adapters->has('foo'));
+    }
+
+    public function testConfiguresPaginatorServicesWhenFound()
+    {
+        $paginator = $this->createMock(AdapterInterface::class);
+        $config = [
+            'paginators' => [
+                'aliases' => [
+                    'test' => 'test-too',
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($paginator) {
+                        return $paginator;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->createMock(ContainerInterface::class);
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('config')
+            ->willReturn(true);
+
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('config')
+            ->willReturn($config);
+
+        $factory = new AdapterPluginManagerFactory();
+        $paginators = $factory($container, AdapterPluginManager::class);
+
+        $this->assertInstanceOf(AdapterPluginManager::class, $paginators);
+        $this->assertTrue($paginators->has('test'));
+        $this->assertSame($paginator, $paginators->get('test'));
+        $this->assertTrue($paginators->has('test-too'));
+        $this->assertSame($paginator, $paginators->get('test-too'));
+    }
 }

--- a/test/AdapterPluginManagerFactoryTest.php
+++ b/test/AdapterPluginManagerFactoryTest.php
@@ -19,10 +19,13 @@ class AdapterPluginManagerFactoryTest extends TestCase
 {
     public function testFactoryReturnsPluginManager()
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
         $factory = new AdapterPluginManagerFactory();
 
-        $adapters = $factory($container, AdapterPluginManager::class);
+        $adapters = $factory($container->reveal(), AdapterPluginManager::class);
         $this->assertInstanceOf(AdapterPluginManager::class, $adapters);
     }
 
@@ -31,11 +34,14 @@ class AdapterPluginManagerFactoryTest extends TestCase
      */
     public function testFactoryConfiguresPluginManagerUnderContainerInterop()
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
         $adapter = $this->prophesize(AdapterInterface::class)->reveal();
 
         $factory = new AdapterPluginManagerFactory();
-        $adapters = $factory($container, AdapterPluginManager::class, [
+        $adapters = $factory($container->reveal(), AdapterPluginManager::class, [
             'services' => [
                 'test' => $adapter,
             ],
@@ -50,6 +56,8 @@ class AdapterPluginManagerFactoryTest extends TestCase
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
 
         $adapter = $this->prophesize(AdapterInterface::class)->reveal();
 


### PR DESCRIPTION
| Q           | A |
| -           | - |
| New Feature | Y |

Adds the ability to specify laminas-servicemanager-style configuration under a "paginators" key in the configuration. When present, it will be used to configure the `Laminas\Paginator\AdapterPluginManager` when retrieved via the application DI container.

Fixes #21
