### PR TITLE
Add Psalm integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
         "laminas/laminas-filter": "^2.9.4",
         "laminas/laminas-servicemanager": "^3.4.1",
         "laminas/laminas-view": "^2.11.4",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "psalm/plugin-phpunit": "^0.15.1",
+        "vimeo/psalm": "^4.6"
     },
     "suggest": {
         "laminas/laminas-cache": "Laminas\\Cache component to support cache features",
@@ -64,6 +66,7 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2b964de5193132f386697e4cb2a2f39",
+    "content-hash": "90b8a088356936202a6b94dd44bbe105",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -127,6 +127,383 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-10T17:06:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/master"
+            },
+            "time": "2020-06-29T18:35:05+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T10:22:58+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:59:24+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
+                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:04:11+00:00"
+        },
+        {
             "name": "container-interop/container-interop",
             "version": "1.2.0",
             "source": {
@@ -233,6 +610,43 @@
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -300,6 +714,107 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.0"
+            },
+            "time": "2021-01-10T17:48:47+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+            },
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "laminas/laminas-cache",
@@ -2023,6 +2538,57 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
+            "name": "netresearch/jsonmapper",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+            },
+            "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.10.4",
             "source": {
@@ -2077,6 +2643,59 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
             },
             "time": "2020-12-20T10:01:03+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2889,6 +3508,66 @@
             "time": "2021-02-02T14:45:58+00:00"
         },
         {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "30ca25ce069bf4943c36e59b7df6954f6af05e64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/30ca25ce069bf4943c36e59b7df6954f6af05e64",
+                "reference": "30ca25ce069bf4943c36e59b7df6954f6af05e64",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.15.1"
+            },
+            "time": "2021-01-23T00:19:07+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "1.0.1",
             "source": {
@@ -2989,6 +3668,56 @@
                 "source": "https://github.com/php-fig/container/tree/master"
             },
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -4123,6 +4852,103 @@
             "time": "2020-10-23T02:01:07+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v5.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-28T22:06:19+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.22.1",
             "source": {
@@ -4202,6 +5028,575 @@
             "time": "2021-01-07T16:49:33+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-22T09:19:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "c95468897f408dd0aca2ff582074423dd0455122"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/c95468897f408dd0aca2ff582074423dd0455122",
+                "reference": "c95468897f408dd0aca2ff582074423dd0455122",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-25T15:14:59+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
@@ -4250,6 +5645,111 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "4.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "e93e532e4eaad6d68c4d7b606853800eaceccc72"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e93e532e4eaad6d68c4d7b606853800eaceccc72",
+                "reference": "e93e532e4eaad6d68c4d7b606853800eaceccc72",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.1",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.4",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.10.1",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.4.2",
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.13",
+                "slevomat/coding-standard": "^6.3.11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.6.1"
+            },
+            "time": "2021-02-17T21:54:11+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4358,6 +5858,56 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,926 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
+  <file src="src/Adapter/Callback.php">
+    <InvalidFunctionCall occurrences="2">
+      <code>call_user_func($this-&gt;countCallback)</code>
+      <code>call_user_func($this-&gt;itemsCallback, $offset, $itemCountPerPage)</code>
+    </InvalidFunctionCall>
+    <InvalidPropertyAssignmentValue occurrences="2">
+      <code>$countCallback</code>
+      <code>$itemsCallback</code>
+    </InvalidPropertyAssignmentValue>
+    <MixedInferredReturnType occurrences="2">
+      <code>array</code>
+      <code>int</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>call_user_func($this-&gt;countCallback)</code>
+      <code>call_user_func($this-&gt;itemsCallback, $offset, $itemCountPerPage)</code>
+    </MixedReturnStatement>
+    <UndefinedDocblockClass occurrences="2">
+      <code>CallbackHandler</code>
+      <code>CallbackHandler</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Adapter/DbSelect.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$adapterOrSqlObject instanceof Sql</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="1">
+      <code>$row</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$row</code>
+    </MixedAssignment>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$rowCount</code>
+    </PropertyNotSetInConstructor>
+    <PropertyTypeCoercion occurrences="1">
+      <code>$resultSetPrototype ?: new ResultSet()</code>
+    </PropertyTypeCoercion>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;rowCount !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Adapter/DbTableGateway.php">
+    <MixedArgument occurrences="1">
+      <code>$select</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$select</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>group</code>
+      <code>having</code>
+      <code>order</code>
+      <code>where</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DbTableGateway</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Adapter/Iterator.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>array|SerializableLimitIterator</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="src/Adapter/Service/CallbackFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>CallbackFactory</code>
+    </DeprecatedInterface>
+    <MissingParamType occurrences="1">
+      <code>$requestedName</code>
+    </MissingParamType>
+    <MixedArgument occurrences="2">
+      <code>$countCallback</code>
+      <code>$itemsCallback</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$countCallback</code>
+      <code>$itemsCallback</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Adapter/Service/DbSelectFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DbSelectFactory</code>
+    </DeprecatedInterface>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingParamType occurrences="1">
+      <code>$requestedName</code>
+    </MissingParamType>
+    <MixedMethodCall occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>DbSelect</code>
+    </MoreSpecificReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Adapter/Service/DbTableGatewayFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DbTableGatewayFactory</code>
+    </DeprecatedInterface>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MissingParamType occurrences="1">
+      <code>$requestedName</code>
+    </MissingParamType>
+    <MixedMethodCall occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>DbTableGateway</code>
+    </MoreSpecificReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Adapter/Service/IteratorFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>IteratorFactory</code>
+    </DeprecatedInterface>
+    <LessSpecificReturnStatement occurrences="1">
+      <code>new $requestedName($iterator)</code>
+    </LessSpecificReturnStatement>
+    <MissingParamType occurrences="1">
+      <code>$requestedName</code>
+    </MissingParamType>
+    <MixedArgument occurrences="2">
+      <code>IteratorAdapter::class</code>
+      <code>IteratorAdapter::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>new $requestedName($iterator)</code>
+    </MixedMethodCall>
+    <MoreSpecificReturnType occurrences="1">
+      <code>IteratorAdapter</code>
+    </MoreSpecificReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+    <UndefinedClass occurrences="3">
+      <code>IteratorAdapter</code>
+      <code>IteratorAdapter</code>
+      <code>IteratorAdapter</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="2">
+      <code>IteratorAdapter</code>
+      <code>IteratorAdapter</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/AdapterPluginManager.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$e-&gt;getCode()</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>validatePlugin</code>
+    </MissingReturnType>
+    <NonInvariantDocblockPropertyType occurrences="3">
+      <code>$aliases</code>
+      <code>$factories</code>
+      <code>$instanceOf</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="src/AdapterPluginManagerFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>AdapterPluginManagerFactory</code>
+    </DeprecatedInterface>
+    <MissingConstructor occurrences="1">
+      <code>$creationOptions</code>
+    </MissingConstructor>
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$requestedName</code>
+    </MissingParamType>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_array($items)</code>
+      <code>static::$adapters === null</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="4">
+      <code>$adapter</code>
+      <code>$adapter</code>
+      <code>$items</code>
+      <code>$items</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$adapter</code>
+      <code>$adapter</code>
+      <code>$items</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Paginator.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$pages-&gt;pagesInRange</code>
+      <code>$pages-&gt;pagesInRange</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="8">
+      <code>$this-&gt;currentItemCount === null</code>
+      <code>$this-&gt;currentItems === null</code>
+      <code>$this-&gt;pageCount === null</code>
+      <code>$this-&gt;pages === null</code>
+      <code>$this-&gt;view === null</code>
+      <code>gettype($scrollingAdapters)</code>
+      <code>is_array($config)</code>
+      <code>static::$scrollingStyles === null</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="4">
+      <code>setCache</code>
+      <code>setDefaultItemCountPerPage</code>
+      <code>setDefaultScrollingStyle</code>
+      <code>setGlobalConfig</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="7">
+      <code>$adapters</code>
+      <code>$items</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$scrollingStyle</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$page[$itemNumber - 1]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="13">
+      <code>$adapters</code>
+      <code>$cacheIterator</code>
+      <code>$cacheIterator</code>
+      <code>$data</code>
+      <code>$data[(int) substr($key, $prefixLength)]</code>
+      <code>$items</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$page</code>
+      <code>$scrollingStyle</code>
+      <code>$this-&gt;currentItems</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>ScrollingStyleInterface</code>
+      <code>Traversable</code>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="3">
+      <code>new $scrollingAdapters(new ServiceManager())</code>
+      <code>setMode</code>
+      <code>setMode</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="3">
+      <code>$this-&gt;currentItems</code>
+      <code>$view-&gt;paginationControl($this)</code>
+      <code>static::getScrollingStylePluginManager()-&gt;get($scrollingStyle)</code>
+    </MixedReturnStatement>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="5">
+      <code>$view</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <PossiblyNullReference occurrences="1">
+      <code>paginationControl</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="7">
+      <code>$currentItemCount</code>
+      <code>$currentItems</code>
+      <code>$filter</code>
+      <code>$itemCountPerPage</code>
+      <code>$pageCount</code>
+      <code>$pages</code>
+      <code>$view</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="7">
+      <code>(bool) $enable</code>
+      <code>(int) $count</code>
+      <code>(int) $itemCountPerPage</code>
+      <code>(int) $itemNumber</code>
+      <code>(int) $pageNumber</code>
+      <code>(int) $pageNumber</code>
+      <code>(int) $pageRange</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="5">
+      <code>$adapter instanceof AdapterAggregateInterface</code>
+      <code>$filter !== null</code>
+      <code>$this-&gt;getCurrentItems() !== null</code>
+      <code>is_object($scrollingAdapters)</code>
+      <code>static::$cache !== null</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>getIterator</code>
+      <code>getIterator</code>
+      <code>paginationControl</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/PaginatorIterator.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;paginator-&gt;getCurrentItems()</code>
+    </LessSpecificReturnStatement>
+    <MixedArgument occurrences="1">
+      <code>$innerKey</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$innerKey</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$innerKey</code>
+    </MixedOperand>
+    <MoreSpecificReturnType occurrences="1">
+      <code>Iterator</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/ScrollingStyle/Sliding.php">
+    <InvalidScalarArgument occurrences="2">
+      <code>$lowerBound</code>
+      <code>$upperBound</code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="src/ScrollingStylePluginManager.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$e-&gt;getCode()</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="1">
+      <code>validatePlugin</code>
+    </MissingReturnType>
+    <NonInvariantDocblockPropertyType occurrences="3">
+      <code>$aliases</code>
+      <code>$factories</code>
+      <code>$instanceOf</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="src/ScrollingStylePluginManagerFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>ScrollingStylePluginManagerFactory</code>
+    </DeprecatedInterface>
+    <MissingConstructor occurrences="1">
+      <code>$creationOptions</code>
+    </MissingConstructor>
+    <MissingParamType occurrences="3">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$requestedName</code>
+    </MissingParamType>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/SerializableLimitIterator.php">
+    <MixedArgument occurrences="7">
+      <code>$currentOffset</code>
+      <code>$currentOffset</code>
+      <code>$currentOffset</code>
+      <code>$dataArr['count']</code>
+      <code>$dataArr['it']</code>
+      <code>$dataArr['offset']</code>
+      <code>$dataArr['pos'] + $dataArr['offset']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="5">
+      <code>$dataArr['count']</code>
+      <code>$dataArr['it']</code>
+      <code>$dataArr['offset']</code>
+      <code>$dataArr['offset']</code>
+      <code>$dataArr['pos']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="5">
+      <code>$current</code>
+      <code>$current</code>
+      <code>$currentOffset</code>
+      <code>$currentOffset</code>
+      <code>$dataArr</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$dataArr['pos']</code>
+    </MixedOperand>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$currentOffset</code>
+    </PossiblyUndefinedVariable>
+  </file>
+  <file src="test/Adapter/ArrayTest.php">
+    <MissingReturnType occurrences="4">
+      <code>testEmptySet</code>
+      <code>testGetsItemsAtOffsetTen</code>
+      <code>testGetsItemsAtOffsetZero</code>
+      <code>testReturnsCorrectCount</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="test/Adapter/CallbackTest.php">
+    <MissingClosureParamType occurrences="2">
+      <code>$itemCountPerPage</code>
+      <code>$offset</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="9">
+      <code>function ($offset, $itemCountPerPage) {</code>
+      <code>function () use ($count) {</code>
+      <code>function () use ($data) {</code>
+      <code>function () {</code>
+      <code>function () {</code>
+      <code>function () {</code>
+      <code>function () {</code>
+      <code>function () {</code>
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MissingReturnType occurrences="5">
+      <code>testMustDefineTwoCallbacksOnConstructor</code>
+      <code>testMustPassArgumentsToGetItemCallback</code>
+      <code>testMustRunCountCallbackToCount</code>
+      <code>testMustRunItemCallbackToGetItems</code>
+      <code>testShouldAcceptAnyCallableOnConstructor</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="2">
+      <code>$itemCountPerPage</code>
+      <code>$offset</code>
+    </MixedArgument>
+  </file>
+  <file src="test/Adapter/DbSelectTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>setMethods</code>
+    </DeprecatedMethod>
+    <InternalMethod occurrences="1">
+      <code>getArrayCopy</code>
+    </InternalMethod>
+    <MissingReturnType occurrences="7">
+      <code>testCount</code>
+      <code>testCountQueryWithLowerColumnNameShouldReturnValidResult</code>
+      <code>testCountQueryWithMissingColumnNameShouldRaiseException</code>
+      <code>testCustomCount</code>
+      <code>testGetArrayCopyShouldContainSelectItems</code>
+      <code>testGetItems</code>
+      <code>testReturnValueIsArray</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="13">
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="10">
+      <code>$this-&gt;mockSelect</code>
+      <code>$this-&gt;mockSelect</code>
+      <code>$this-&gt;mockSelect</code>
+      <code>$this-&gt;mockSelect</code>
+      <code>$this-&gt;mockSelectCount</code>
+      <code>$this-&gt;mockSelectCount</code>
+      <code>$this-&gt;mockSql</code>
+      <code>$this-&gt;mockSql</code>
+      <code>$this-&gt;mockSql</code>
+      <code>$this-&gt;mockSql</code>
+    </PossiblyInvalidArgument>
+    <UndefinedDocblockClass occurrences="12">
+      <code>$this-&gt;mockResult</code>
+      <code>$this-&gt;mockResult</code>
+      <code>$this-&gt;mockResult</code>
+      <code>$this-&gt;mockResult</code>
+      <code>$this-&gt;mockSelect</code>
+      <code>$this-&gt;mockSelect</code>
+      <code>$this-&gt;mockSelect</code>
+      <code>PHPUnit_Framework_MockObject_MockObject|ResultInterface</code>
+      <code>PHPUnit_Framework_MockObject_MockObject|Select</code>
+      <code>PHPUnit_Framework_MockObject_MockObject|Select</code>
+      <code>PHPUnit_Framework_MockObject_MockObject|Sql</code>
+      <code>PHPUnit_Framework_MockObject_MockObject|StatementInterface</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedMethod occurrences="3">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/Adapter/DbTableGatewayTest.php">
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$mockStatement</code>
+    </InvalidPropertyAssignmentValue>
+    <MissingReturnType occurrences="5">
+      <code>testCount</code>
+      <code>testGetItems</code>
+      <code>testGetItemsWithWhereAndOrder</code>
+      <code>testGetItemsWithWhereAndOrderAndGroup</code>
+      <code>testGetItemsWithWhereAndOrderAndGroupAndHaving</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="14">
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <UndefinedDocblockClass occurrences="8">
+      <code>$this-&gt;mockStatement</code>
+      <code>$this-&gt;mockStatement</code>
+      <code>$this-&gt;mockStatement</code>
+      <code>$this-&gt;mockStatement</code>
+      <code>$this-&gt;mockStatement</code>
+      <code>$this-&gt;mockStatement</code>
+      <code>$this-&gt;mockStatement</code>
+      <code>PHPUnit_Framework_MockObject_MockObject</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="test/Adapter/IteratorTest.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>'LimitIterator'</code>
+      <code>'LimitIterator'</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>assertEmpty</code>
+    </DocblockTypeContradiction>
+    <MissingReturnType occurrences="7">
+      <code>testDoesNotThrowOutOfBoundsExceptionIfIteratorIsEmpty</code>
+      <code>testEmptySet</code>
+      <code>testGetItemsSerializable</code>
+      <code>testGetsItemsAtOffsetTen</code>
+      <code>testGetsItemsAtOffsetZero</code>
+      <code>testReturnsCorrectCount</code>
+      <code>testThrowsExceptionIfNotCountable</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="4">
+      <code>$item</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$items</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getInnerIterator</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>getInnerIterator</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;paginator</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="test/Adapter/NullFillTest.php">
+    <MissingReturnType occurrences="5">
+      <code>testAdapterReturnsCorrectValues</code>
+      <code>testEmptySet</code>
+      <code>testGetsItems</code>
+      <code>testReturnsCorrectCount</code>
+      <code>testSetOfOne</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="1">
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="test/AdapterPluginManagerCompatibilityTest.php">
+    <MixedArgument occurrences="3">
+      <code>$target</code>
+      <code>$target</code>
+      <code>$target</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$alias</code>
+      <code>$aliases</code>
+      <code>$target</code>
+    </MixedAssignment>
+    <MoreSpecificReturnType occurrences="1">
+      <code>iterable&lt;string, array{0: string, 1: string}&gt;</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="test/AdapterPluginManagerFactoryTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$container</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>function ($container) use ($paginator) {</code>
+    </MissingClosureReturnType>
+    <MissingReturnType occurrences="5">
+      <code>testConfiguresPaginatorServicesWhenFound</code>
+      <code>testDoesNotConfigureAdditionalPaginatorsWhenConfigServiceDoesNotContainPaginatorsConfig</code>
+      <code>testFactoryConfiguresPluginManagerUnderContainerInterop</code>
+      <code>testFactoryConfiguresPluginManagerUnderServiceManagerV2</code>
+      <code>testFactoryReturnsPluginManager</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/AdapterPluginManagerTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>setMethods</code>
+    </DeprecatedMethod>
+    <MissingClosureReturnType occurrences="2">
+      <code>function () {</code>
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MissingReturnType occurrences="2">
+      <code>testCanRetrieveAdapterPlugin</code>
+      <code>testFactoryCreatedDbSelectCanUseCustomCountSelect</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="7">
+      <code>$count</code>
+      <code>$plugin</code>
+      <code>$plugin</code>
+      <code>$plugin</code>
+      <code>$plugin</code>
+      <code>$plugin</code>
+      <code>$plugin</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>count</code>
+    </MixedMethodCall>
+  </file>
+  <file src="test/FactoryTest.php">
+    <MissingReturnType occurrences="7">
+      <code>testCanFactoryPaginatorWithDbSelect</code>
+      <code>testCanFactoryPaginatorWithOneBadParameter</code>
+      <code>testCanFactoryPaginatorWithOneParameterWithArrayAdapter</code>
+      <code>testCanFactoryPaginatorWithOneParameterWithDbAdapter</code>
+      <code>testCanFactoryPaginatorWithStringAdapterAggregate</code>
+      <code>testCanFactoryPaginatorWithStringAdapterName</code>
+      <code>testCanFactoryPaginatorWithStringAdapterObject</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/PaginatorIteratorTest.php">
+    <MissingReturnType occurrences="2">
+      <code>testIteratorFlattensPaginator</code>
+      <code>testIteratorReturnsInvalidOnEmptyIterator</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/PaginatorTest.php">
+    <ArgumentTypeCoercion occurrences="6">
+      <code>'ArrayIterator'</code>
+      <code>'ArrayIterator'</code>
+      <code>'ArrayIterator'</code>
+      <code>'ArrayObject'</code>
+      <code>'ArrayObject'</code>
+      <code>'ArrayObject'</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="2">
+      <code>setMethods</code>
+      <code>setMethods</code>
+    </DeprecatedMethod>
+    <InvalidArgument occurrences="5">
+      <code>'not array'</code>
+      <code>ExceptionInterface::class</code>
+      <code>[]</code>
+      <code>\Laminas\Paginator\Exception\ExceptionInterface::class</code>
+      <code>new stdClass()</code>
+    </InvalidArgument>
+    <InvalidMethodCall occurrences="1">
+      <code>key</code>
+    </InvalidMethodCall>
+    <InvalidPropertyFetch occurrences="2">
+      <code>$this-&gt;config-&gt;default</code>
+      <code>$this-&gt;config-&gt;testing</code>
+    </InvalidPropertyFetch>
+    <InvalidScalarArgument occurrences="17">
+      <code>0.5</code>
+      <code>0.5</code>
+      <code>1.99</code>
+      <code>1.99</code>
+      <code>2.3</code>
+      <code>2.3</code>
+      <code>3.3</code>
+      <code>3.3</code>
+      <code>3.3</code>
+      <code>5.1</code>
+      <code>5.1</code>
+      <code>9.06</code>
+      <code>10.06</code>
+      <code>10.5</code>
+      <code>11.5</code>
+      <code>11.7889</code>
+      <code>12.7889</code>
+    </InvalidScalarArgument>
+    <MissingParamType occurrences="1">
+      <code>$path</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="66">
+      <code>_getTmpDir</code>
+      <code>_restorePaginatorDefaults</code>
+      <code>_rmDirRecursive</code>
+      <code>testAcceptAndHandlePaginatorAdapterAggregateDataInFactory</code>
+      <code>testAcceptAndHandlePaginatorAdapterAggregateInConstructor</code>
+      <code>testAcceptsComplexAdapters</code>
+      <code>testAcceptsTraversableInstanceFromAdapter</code>
+      <code>testArrayAccessInClassSerializableLimitIterator</code>
+      <code>testCacheDoesNotDisturbResultsWhenChangingParam</code>
+      <code>testCachedItem</code>
+      <code>testCastsIntegerValuesToInteger</code>
+      <code>testClearPageItemCache</code>
+      <code>testDbSelectAdapterShouldProduceValidCacheId</code>
+      <code>testFilter</code>
+      <code>testGeneratesViewIfNonexistent</code>
+      <code>testGetCacheId</code>
+      <code>testGetCacheIdWithInheritedClass</code>
+      <code>testGetCacheIdWithSameAdapterAndDifferentAttributes</code>
+      <code>testGetSetDefaultItemCountPerPage</code>
+      <code>testGetsAbsoluteItemNumber</code>
+      <code>testGetsAndSetsCurrentPageNumber</code>
+      <code>testGetsAndSetsDefaultScrollingStyle</code>
+      <code>testGetsAndSetsItemCountPerPage</code>
+      <code>testGetsAndSetsItemCounterPerPageOfNegativeOne</code>
+      <code>testGetsAndSetsItemCounterPerPageOfNull</code>
+      <code>testGetsAndSetsItemCounterPerPageOfZero</code>
+      <code>testGetsAndSetsPageRange</code>
+      <code>testGetsAndSetsView</code>
+      <code>testGetsCurrentItemCount</code>
+      <code>testGetsCurrentItems</code>
+      <code>testGetsItem</code>
+      <code>testGetsItemCount</code>
+      <code>testGetsItemsByPage</code>
+      <code>testGetsItemsByPageHandleDbSelectAdapter</code>
+      <code>testGetsIterator</code>
+      <code>testGetsPageCount</code>
+      <code>testGetsPagesForPageOne</code>
+      <code>testGetsPagesForPageTwo</code>
+      <code>testGetsPagesInOutOfBoundsRange</code>
+      <code>testGetsPagesInSubsetRange</code>
+      <code>testGivesCorrectItemCount</code>
+      <code>testHasCorrectCountAfterInit</code>
+      <code>testHasCorrectCountOfAllItemsAfterInit</code>
+      <code>testInvalidDataInConstructor_ThrowsException</code>
+      <code>testItemCountPerPageByDefault</code>
+      <code>testItemCountsForEmptyItemSet</code>
+      <code>testKeepsCurrentPageNumberAfterItemCountPerPageSet</code>
+      <code>testLoadScrollingStyleWithDigitThrowsInvalidArgumentException</code>
+      <code>testLoadScrollingStyleWithObjectThrowsInvalidArgumentException</code>
+      <code>testLoadsFromConfig</code>
+      <code>testNegativeItemNumbers</code>
+      <code>testNormalizesItemNumber</code>
+      <code>testNormalizesItemNumberWhenGivenAFloat</code>
+      <code>testNormalizesPageNumber</code>
+      <code>testNormalizesPageNumberWhenGivenAFloat</code>
+      <code>testRenders</code>
+      <code>testRendersWithPartial</code>
+      <code>testRendersWithoutPartial</code>
+      <code>testRepetitiveCallOfCountResultsOfZero</code>
+      <code>testSetGlobalConfigThrowsInvalidArgumentException</code>
+      <code>testSetScrollingStylePluginManagerWithAdapterThrowsInvalidArgumentException</code>
+      <code>testSetScrollingStylePluginManagerWithStringThrowsInvalidArgumentException</code>
+      <code>testThrowsExceptionWhenCollectionIsEmpty</code>
+      <code>testThrowsExceptionWhenRetrievingNonexistentItemFromLastPage</code>
+      <code>testToJson</code>
+      <code>testWithCacheDisabled</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$path</code>
+      <code>$path</code>
+      <code>$this-&gt;config-&gt;default</code>
+      <code>$this-&gt;config-&gt;testing</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="14">
+      <code>$firstCacheId</code>
+      <code>$firstOutputGetCacheInternalId</code>
+      <code>$firstOutputGetCacheInternalId</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$item</code>
+      <code>$outputGetCacheId</code>
+      <code>$outputGetCacheInternalId</code>
+      <code>$outputGetCacheInternalId</code>
+      <code>$page1</code>
+      <code>$pageItems</code>
+      <code>$secondCacheIde</code>
+      <code>$secondOutputGetCacheInternalId</code>
+      <code>$secondOutputGetCacheInternalId</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="3">
+      <code>$outputGetCacheInternalId</code>
+      <code>$outputGetCacheInternalId</code>
+      <code>$path</code>
+    </MixedOperand>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>addPath</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+      <code>Config\Factory::fromFile(__DIR__ . '/_files/config.xml', true)</code>
+    </PossiblyInvalidPropertyAssignmentValue>
+    <PossiblyNullArgument occurrences="1">
+      <code>$resultSet-&gt;getDataSource()</code>
+    </PossiblyNullArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>$items</code>
+      <code>addPath</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/ScrollingStyle/AllTest.php">
+    <MissingReturnType occurrences="6">
+      <code>testGetsNextAndPreviousPageForFirstPage</code>
+      <code>testGetsNextAndPreviousPageForLastPage</code>
+      <code>testGetsNextAndPreviousPageForMiddlePage</code>
+      <code>testGetsNextAndPreviousPageForSecondLastPage</code>
+      <code>testGetsNextAndPreviousPageForSecondPage</code>
+      <code>testGetsPages</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="test/ScrollingStyle/ElasticTest.php">
+    <MissingReturnType occurrences="12">
+      <code>testGetsNextAndPreviousPageForFirstPage</code>
+      <code>testGetsNextAndPreviousPageForLastPage</code>
+      <code>testGetsNextAndPreviousPageForMiddlePage</code>
+      <code>testGetsNextAndPreviousPageForSecondLastPage</code>
+      <code>testGetsNextAndPreviousPageForSecondPage</code>
+      <code>testGetsPagesInRangeForFirstPage</code>
+      <code>testGetsPagesInRangeForLastPage</code>
+      <code>testGetsPagesInRangeForSecondPage</code>
+      <code>testGetsPagesInRangeForTenthPage</code>
+      <code>testNoPagesBeforeSecondLastPageEqualsPageRangeMinTwo</code>
+      <code>testNoPagesOnLastPageEqualsPageRange</code>
+      <code>testNoPagesOnSecondLastPageEqualsPageRangeMinOne</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="3">
+      <code>$pages-&gt;pagesInRange</code>
+      <code>$pages-&gt;pagesInRange</code>
+      <code>$pages-&gt;pagesInRange</code>
+    </MixedArgument>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="test/ScrollingStyle/JumpingTest.php">
+    <MissingReturnType occurrences="9">
+      <code>testGetsNextAndPreviousPageForFirstPage</code>
+      <code>testGetsNextAndPreviousPageForLastPage</code>
+      <code>testGetsNextAndPreviousPageForMiddlePage</code>
+      <code>testGetsNextAndPreviousPageForSecondLastPage</code>
+      <code>testGetsNextAndPreviousPageForSecondPage</code>
+      <code>testGetsPagesInRangeForFirstPage</code>
+      <code>testGetsPagesInRangeForLastPage</code>
+      <code>testGetsPagesInRangeForSecondLastPage</code>
+      <code>testGetsPagesInRangeForSecondPage</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="test/ScrollingStyle/SlidingTest.php">
+    <MissingReturnType occurrences="10">
+      <code>testAcceptsPageRangeLargerThanPageCount</code>
+      <code>testGetsNextAndPreviousPageForFirstPage</code>
+      <code>testGetsNextAndPreviousPageForLastPage</code>
+      <code>testGetsNextAndPreviousPageForMiddlePage</code>
+      <code>testGetsNextAndPreviousPageForSecondLastPage</code>
+      <code>testGetsNextAndPreviousPageForSecondPage</code>
+      <code>testGetsPagesInRangeForFifthPage</code>
+      <code>testGetsPagesInRangeForFirstPage</code>
+      <code>testGetsPagesInRangeForLastPage</code>
+      <code>testGetsPagesInRangeForSecondPage</code>
+    </MissingReturnType>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </PossiblyNullPropertyAssignmentValue>
+  </file>
+  <file src="test/ScrollingStylePluginManagerFactoryTest.php">
+    <MissingReturnType occurrences="3">
+      <code>testFactoryConfiguresPluginManagerUnderContainerInterop</code>
+      <code>testFactoryConfiguresPluginManagerUnderServiceManagerV2</code>
+      <code>testFactoryReturnsPluginManager</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/TestAdapter.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>new ArrayObject(range(1, 10))</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>getItems</code>
+    </InvalidReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$pageNumber</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="test/TestAsset/TestDbSelectAdapter.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$pageNumber</code>
+    </ParamNameMismatch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>TestDbSelectAdapter</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/bootstrap.php">
+    <MixedArgument occurrences="1">
+      <code>$phpUnitVersion</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$phpUnitVersion</code>
+    </MixedAssignment>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -20,7 +20,7 @@ interface AdapterInterface extends Countable
      *
      * @param  int $offset Page offset
      * @param  int $itemCountPerPage Number of items per page
-     * @return array
+     * @return iterable
      */
     public function getItems($offset, $itemCountPerPage);
 }

--- a/src/Adapter/Iterator.php
+++ b/src/Adapter/Iterator.php
@@ -49,6 +49,7 @@ class Iterator implements AdapterInterface
      * @param  int $offset Page offset
      * @param  int $itemCountPerPage Number of items per page
      * @return array|SerializableLimitIterator
+     * @psalm-return iterable<array-key, mixed>
      */
     public function getItems($offset, $itemCountPerPage)
     {

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -124,9 +124,7 @@ class AdapterPluginManager extends AbstractPluginManager
      * Validate that a plugin is an adapter (v2)
      *
      * @param mixed $plugin
-     *
      * @throws Exception\RuntimeException
-     *
      * @return void
      */
     public function validatePlugin($plugin)

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -124,7 +124,10 @@ class AdapterPluginManager extends AbstractPluginManager
      * Validate that a plugin is an adapter (v2)
      *
      * @param mixed $plugin
+     *
      * @throws Exception\RuntimeException
+     *
+     * @return void
      */
     public function validatePlugin($plugin)
     {

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -183,7 +183,10 @@ class Paginator implements Countable, IteratorAggregate
      * Set a global config
      *
      * @param array|Traversable $config
+     *
      * @throws Exception\InvalidArgumentException
+     *
+     * @return void
      */
     public static function setGlobalConfig($config)
     {
@@ -234,6 +237,8 @@ class Paginator implements Countable, IteratorAggregate
      * Set the default item count per page
      *
      * @param int $count
+     *
+     * @return void
      */
     public static function setDefaultItemCountPerPage($count)
     {
@@ -242,6 +247,8 @@ class Paginator implements Countable, IteratorAggregate
 
     /**
      * Sets a cache object
+     *
+     * @return void
      */
     public static function setCache(CacheStorage $cache)
     {
@@ -251,7 +258,9 @@ class Paginator implements Countable, IteratorAggregate
     /**
      * Sets the default scrolling style.
      *
-     * @param  string $scrollingStyle
+     * @param string $scrollingStyle
+     *
+     * @return void
      */
     public static function setDefaultScrollingStyle($scrollingStyle = 'Sliding')
     {

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -183,9 +183,7 @@ class Paginator implements Countable, IteratorAggregate
      * Set a global config
      *
      * @param array|Traversable $config
-     *
      * @throws Exception\InvalidArgumentException
-     *
      * @return void
      */
     public static function setGlobalConfig($config)
@@ -237,7 +235,6 @@ class Paginator implements Countable, IteratorAggregate
      * Set the default item count per page
      *
      * @param int $count
-     *
      * @return void
      */
     public static function setDefaultItemCountPerPage($count)
@@ -259,7 +256,6 @@ class Paginator implements Countable, IteratorAggregate
      * Sets the default scrolling style.
      *
      * @param string $scrollingStyle
-     *
      * @return void
      */
     public static function setDefaultScrollingStyle($scrollingStyle = 'Sliding')

--- a/src/ScrollingStylePluginManager.php
+++ b/src/ScrollingStylePluginManager.php
@@ -100,7 +100,10 @@ class ScrollingStylePluginManager extends AbstractPluginManager
      * Validate a plugin (v2)
      *
      * @param mixed $plugin
+     *
      * @throws Exception\InvalidArgumentException
+     *
+     * @return void
      */
     public function validatePlugin($plugin)
     {

--- a/src/ScrollingStylePluginManager.php
+++ b/src/ScrollingStylePluginManager.php
@@ -100,9 +100,7 @@ class ScrollingStylePluginManager extends AbstractPluginManager
      * Validate a plugin (v2)
      *
      * @param mixed $plugin
-     *
      * @throws Exception\InvalidArgumentException
-     *
      * @return void
      */
     public function validatePlugin($plugin)

--- a/test/Adapter/ArrayTest.php
+++ b/test/Adapter/ArrayTest.php
@@ -40,29 +40,31 @@ class ArrayTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsItemsAtOffsetZero()
+    public function testGetsItemsAtOffsetZero(): void
     {
         $expected = range(1, 10);
         $actual   = $this->adapter->getItems(0, 10);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsItemsAtOffsetTen()
+    public function testGetsItemsAtOffsetTen(): void
     {
         $expected = range(11, 20);
         $actual   = $this->adapter->getItems(10, 10);
         $this->assertEquals($expected, $actual);
     }
 
-    public function testReturnsCorrectCount()
+    public function testReturnsCorrectCount(): void
     {
         $this->assertEquals(101, $this->adapter->count());
     }
 
     /**
      * @group Laminas-4151
+     *
+     * @return void
      */
-    public function testEmptySet()
+    public function testEmptySet(): void
     {
         $this->adapter = new Adapter\ArrayAdapter([]);
         $actual        = $this->adapter->getItems(0, 10);

--- a/test/Adapter/ArrayTest.php
+++ b/test/Adapter/ArrayTest.php
@@ -61,8 +61,6 @@ class ArrayTest extends TestCase
 
     /**
      * @group Laminas-4151
-     *
-     * @return void
      */
     public function testEmptySet(): void
     {

--- a/test/Adapter/CallbackTest.php
+++ b/test/Adapter/CallbackTest.php
@@ -18,12 +18,17 @@ use function range;
  */
 class CallbackTest extends TestCase
 {
-    public function testMustDefineTwoCallbacksOnConstructor()
+    public function testMustDefineTwoCallbacksOnConstructor(): void
     {
-        $itemsCallback = function () {
+        $itemsCallback = /**
+         * @return array
+         *
+         * @psalm-return array<empty, empty>
+         */
+        function (): array {
             return [];
         };
-        $countCallback = function () {
+        $countCallback = function (): int {
             return 0;
         };
         $adapter       = new Callback($itemsCallback, $countCallback);
@@ -32,9 +37,14 @@ class CallbackTest extends TestCase
         $this->assertSame(0, $adapter->count());
     }
 
-    public function testShouldAcceptAnyCallableOnConstructor()
+    public function testShouldAcceptAnyCallableOnConstructor(): void
     {
-        $itemsCallback = function () {
+        $itemsCallback = /**
+         * @return int[]
+         *
+         * @psalm-return non-empty-list<int>
+         */
+        function (): array {
             return range(1, 10);
         };
         $countCallback = 'rand';
@@ -44,38 +54,48 @@ class CallbackTest extends TestCase
         $this->assertIsInt($adapter->count());
     }
 
-    public function testMustRunItemCallbackToGetItems()
+    public function testMustRunItemCallbackToGetItems(): void
     {
         $data          = range(1, 10);
-        $itemsCallback = function () use ($data) {
+        $itemsCallback = /**
+         * @return int[]
+         *
+         * @psalm-return non-empty-list<int>
+         */
+        function () use ($data): array {
             return $data;
         };
-        $countCallback = function () {
+        $countCallback = function (): void {
         };
         $adapter       = new Callback($itemsCallback, $countCallback);
 
         $this->assertSame($data, $adapter->getItems(0, 10));
     }
 
-    public function testMustPassArgumentsToGetItemCallback()
+    public function testMustPassArgumentsToGetItemCallback(): void
     {
         $data          = [0, 1, 2, 3];
-        $itemsCallback = function ($offset, $itemCountPerPage) {
+        $itemsCallback = /**
+         * @return (float|int|string)[]
+         *
+         * @psalm-return non-empty-list<float|int|string>
+         */
+        function ($offset, $itemCountPerPage): array {
             return range($offset, $itemCountPerPage);
         };
-        $countCallback = function () {
+        $countCallback = function (): void {
         };
         $adapter       = new Callback($itemsCallback, $countCallback);
 
         $this->assertSame($data, $adapter->getItems(0, 3));
     }
 
-    public function testMustRunCountCallbackToCount()
+    public function testMustRunCountCallbackToCount(): void
     {
         $count         = 1988;
-        $itemsCallback = function () {
+        $itemsCallback = function (): void {
         };
-        $countCallback = function () use ($count) {
+        $countCallback = function () use ($count): int {
             return $count;
         };
         $adapter       = new Callback($itemsCallback, $countCallback);

--- a/test/Adapter/CallbackTest.php
+++ b/test/Adapter/CallbackTest.php
@@ -21,9 +21,8 @@ class CallbackTest extends TestCase
     public function testMustDefineTwoCallbacksOnConstructor(): void
     {
         $itemsCallback = /**
-         * @return array
-         *
-         * @psalm-return array<empty, empty>
+        $itemsCallback =  * @return array
+        $itemsCallback =  * @psalm-return array<empty, empty>
          */
         function (): array {
             return [];
@@ -40,9 +39,8 @@ class CallbackTest extends TestCase
     public function testShouldAcceptAnyCallableOnConstructor(): void
     {
         $itemsCallback = /**
-         * @return int[]
-         *
-         * @psalm-return non-empty-list<int>
+        $itemsCallback =  * @return int[]
+        $itemsCallback =  * @psalm-return non-empty-list<int>
          */
         function (): array {
             return range(1, 10);
@@ -58,9 +56,8 @@ class CallbackTest extends TestCase
     {
         $data          = range(1, 10);
         $itemsCallback = /**
-         * @return int[]
-         *
-         * @psalm-return non-empty-list<int>
+        $itemsCallback =  * @return int[]
+        $itemsCallback =  * @psalm-return non-empty-list<int>
          */
         function () use ($data): array {
             return $data;
@@ -76,9 +73,8 @@ class CallbackTest extends TestCase
     {
         $data          = [0, 1, 2, 3];
         $itemsCallback = /**
-         * @return (float|int|string)[]
-         *
-         * @psalm-return non-empty-list<float|int|string>
+        $itemsCallback =  * @return (float|int|string)[]
+        $itemsCallback =  * @psalm-return non-empty-list<float|int|string>
          */
         function ($offset, $itemCountPerPage): array {
             return range($offset, $itemCountPerPage);

--- a/test/Adapter/DbSelectTest.php
+++ b/test/Adapter/DbSelectTest.php
@@ -139,8 +139,6 @@ class DbSelectTest extends TestCase
     /**
      * @group 6817
      * @group 6812
-     *
-     * @return void
      */
     public function testReturnValueIsArray(): void
     {

--- a/test/Adapter/DbSelectTest.php
+++ b/test/Adapter/DbSelectTest.php
@@ -83,7 +83,7 @@ class DbSelectTest extends TestCase
         $this->dbSelect        = new DbSelect($this->mockSelect, $this->mockSql);
     }
 
-    public function testGetItems()
+    public function testGetItems(): void
     {
         $this->mockSelect->expects($this->once())->method('limit')->with($this->equalTo(10));
         $this->mockSelect->expects($this->once())->method('offset')->with($this->equalTo(2));
@@ -91,7 +91,7 @@ class DbSelectTest extends TestCase
         $this->assertEquals([], $items);
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $this->mockResult->expects($this->once())->method('current')
             ->will($this->returnValue([DbSelect::ROW_COUNT_COLUMN_NAME => 5]));
@@ -102,7 +102,7 @@ class DbSelectTest extends TestCase
         $this->assertEquals(5, $count);
     }
 
-    public function testCountQueryWithLowerColumnNameShouldReturnValidResult()
+    public function testCountQueryWithLowerColumnNameShouldReturnValidResult(): void
     {
         $this->dbSelect = new DbSelect($this->mockSelect, $this->mockSql);
         $this->mockResult
@@ -114,7 +114,7 @@ class DbSelectTest extends TestCase
         $this->assertEquals(7, $count);
     }
 
-    public function testCountQueryWithMissingColumnNameShouldRaiseException()
+    public function testCountQueryWithMissingColumnNameShouldRaiseException(): void
     {
         $this->dbSelect = new DbSelect($this->mockSelect, $this->mockSql);
         $this->mockResult
@@ -126,7 +126,7 @@ class DbSelectTest extends TestCase
         $this->dbSelect->count();
     }
 
-    public function testCustomCount()
+    public function testCustomCount(): void
     {
         $this->dbSelect = new DbSelect($this->mockSelect, $this->mockSql, null, $this->mockSelectCount);
         $this->mockResult->expects($this->once())->method('current')
@@ -139,13 +139,15 @@ class DbSelectTest extends TestCase
     /**
      * @group 6817
      * @group 6812
+     *
+     * @return void
      */
-    public function testReturnValueIsArray()
+    public function testReturnValueIsArray(): void
     {
         $this->assertIsArray($this->dbSelect->getItems(0, 10));
     }
 
-    public function testGetArrayCopyShouldContainSelectItems()
+    public function testGetArrayCopyShouldContainSelectItems(): void
     {
         $this->dbSelect = new DbSelect(
             $this->mockSelect,

--- a/test/Adapter/DbTableGatewayTest.php
+++ b/test/Adapter/DbTableGatewayTest.php
@@ -60,7 +60,7 @@ class DbTableGatewayTest extends TestCase
         $this->mockTableGateway = $mockTableGateway;
     }
 
-    public function testGetItems()
+    public function testGetItems(): void
     {
         $this->dbTableGateway = new DbTableGateway($this->mockTableGateway);
 
@@ -74,7 +74,7 @@ class DbTableGatewayTest extends TestCase
         $this->assertEquals([], $items);
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $this->dbTableGateway = new DbTableGateway($this->mockTableGateway);
 
@@ -91,7 +91,7 @@ class DbTableGatewayTest extends TestCase
         $this->assertEquals(10, $count);
     }
 
-    public function testGetItemsWithWhereAndOrder()
+    public function testGetItemsWithWhereAndOrder(): void
     {
         $where                = "foo = bar";
         $order                = "foo";
@@ -107,7 +107,7 @@ class DbTableGatewayTest extends TestCase
         $this->assertEquals([], $items);
     }
 
-    public function testGetItemsWithWhereAndOrderAndGroup()
+    public function testGetItemsWithWhereAndOrderAndGroup(): void
     {
         $where                = "foo = bar";
         $order                = "foo";
@@ -130,7 +130,7 @@ class DbTableGatewayTest extends TestCase
         $this->assertEquals([], $items);
     }
 
-    public function testGetItemsWithWhereAndOrderAndGroupAndHaving()
+    public function testGetItemsWithWhereAndOrderAndGroupAndHaving(): void
     {
         $where                = "foo = bar";
         $order                = "foo";

--- a/test/Adapter/IteratorTest.php
+++ b/test/Adapter/IteratorTest.php
@@ -48,7 +48,7 @@ class IteratorTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsItemsAtOffsetZero()
+    public function testGetsItemsAtOffsetZero(): void
     {
         $actual = $this->adapter->getItems(0, 10);
         $this->assertInstanceOf('LimitIterator', $actual);
@@ -60,7 +60,7 @@ class IteratorTest extends TestCase
         }
     }
 
-    public function testGetsItemsAtOffsetTen()
+    public function testGetsItemsAtOffsetTen(): void
     {
         $actual = $this->adapter->getItems(10, 10);
         $this->assertInstanceOf('LimitIterator', $actual);
@@ -72,12 +72,12 @@ class IteratorTest extends TestCase
         }
     }
 
-    public function testReturnsCorrectCount()
+    public function testReturnsCorrectCount(): void
     {
         $this->assertEquals(101, $this->adapter->count());
     }
 
-    public function testThrowsExceptionIfNotCountable()
+    public function testThrowsExceptionIfNotCountable(): void
     {
         $iterator = new LimitIterator(new ArrayIterator(range(1, 101)));
 
@@ -88,8 +88,10 @@ class IteratorTest extends TestCase
 
     /**
      * @group Laminas-4151
+     *
+     * @return void
      */
-    public function testDoesNotThrowOutOfBoundsExceptionIfIteratorIsEmpty()
+    public function testDoesNotThrowOutOfBoundsExceptionIfIteratorIsEmpty(): void
     {
         $this->paginator = new Paginator(new Adapter\Iterator(new ArrayIterator([])));
         $items           = $this->paginator->getCurrentItems();
@@ -103,9 +105,12 @@ class IteratorTest extends TestCase
 
     /**
      * @group Laminas-8084
+     *
+     * @return void
      */
-    public function testGetItemsSerializable()
+    public function testGetItemsSerializable(): void
     {
+        /** @psalm-var \Laminas\Paginator\SerializableLimitIterator $items */
         $items         = $this->adapter->getItems(0, 1);
         $innerIterator = $items->getInnerIterator();
         $items         = unserialize(serialize($items));
@@ -118,8 +123,10 @@ class IteratorTest extends TestCase
 
     /**
      * @group Laminas-4151
+     *
+     * @return void
      */
-    public function testEmptySet()
+    public function testEmptySet(): void
     {
         $iterator      = new ArrayIterator([]);
         $this->adapter = new Adapter\Iterator($iterator);

--- a/test/Adapter/IteratorTest.php
+++ b/test/Adapter/IteratorTest.php
@@ -13,6 +13,7 @@ use Laminas\Paginator\Adapter;
 use Laminas\Paginator\Adapter\Exception\InvalidArgumentException;
 use Laminas\Paginator\Adapter\Iterator;
 use Laminas\Paginator\Paginator;
+use Laminas\Paginator\SerializableLimitIterator;
 use LimitIterator;
 use PHPUnit\Framework\TestCase;
 
@@ -88,8 +89,6 @@ class IteratorTest extends TestCase
 
     /**
      * @group Laminas-4151
-     *
-     * @return void
      */
     public function testDoesNotThrowOutOfBoundsExceptionIfIteratorIsEmpty(): void
     {
@@ -105,12 +104,10 @@ class IteratorTest extends TestCase
 
     /**
      * @group Laminas-8084
-     *
-     * @return void
      */
     public function testGetItemsSerializable(): void
     {
-        /** @psalm-var \Laminas\Paginator\SerializableLimitIterator $items */
+        /** @psalm-var SerializableLimitIterator $items */
         $items         = $this->adapter->getItems(0, 1);
         $innerIterator = $items->getInnerIterator();
         $items         = unserialize(serialize($items));
@@ -123,8 +120,6 @@ class IteratorTest extends TestCase
 
     /**
      * @group Laminas-4151
-     *
-     * @return void
      */
     public function testEmptySet(): void
     {

--- a/test/Adapter/NullFillTest.php
+++ b/test/Adapter/NullFillTest.php
@@ -42,21 +42,23 @@ class NullFillTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsItems()
+    public function testGetsItems(): void
     {
         $actual = $this->adapter->getItems(0, 10);
         $this->assertEquals(array_fill(0, 10, null), $actual);
     }
 
-    public function testReturnsCorrectCount()
+    public function testReturnsCorrectCount(): void
     {
         $this->assertEquals(101, $this->adapter->count());
     }
 
     /**
      * @group Laminas-3873
+     *
+     * @return void
      */
-    public function testAdapterReturnsCorrectValues()
+    public function testAdapterReturnsCorrectValues(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\NullFill(2));
         $paginator->setCurrentPageNumber(1);
@@ -79,8 +81,10 @@ class NullFillTest extends TestCase
 
     /**
      * @group Laminas-4151
+     *
+     * @return void
      */
-    public function testEmptySet()
+    public function testEmptySet(): void
     {
         $this->adapter = new Adapter\NullFill(0);
         $actual        = $this->adapter->getItems(0, 10);
@@ -89,8 +93,10 @@ class NullFillTest extends TestCase
 
     /**
      * Verify that the fix for Laminas-4151 doesn't create an OBO error
+     *
+     * @return void
      */
-    public function testSetOfOne()
+    public function testSetOfOne(): void
     {
         $this->adapter = new Adapter\NullFill(1);
         $actual        = $this->adapter->getItems(0, 10);

--- a/test/Adapter/NullFillTest.php
+++ b/test/Adapter/NullFillTest.php
@@ -55,8 +55,6 @@ class NullFillTest extends TestCase
 
     /**
      * @group Laminas-3873
-     *
-     * @return void
      */
     public function testAdapterReturnsCorrectValues(): void
     {
@@ -81,8 +79,6 @@ class NullFillTest extends TestCase
 
     /**
      * @group Laminas-4151
-     *
-     * @return void
      */
     public function testEmptySet(): void
     {
@@ -93,8 +89,6 @@ class NullFillTest extends TestCase
 
     /**
      * Verify that the fix for Laminas-4151 doesn't create an OBO error
-     *
-     * @return void
      */
     public function testSetOfOne(): void
     {

--- a/test/AdapterPluginManagerFactoryTest.php
+++ b/test/AdapterPluginManagerFactoryTest.php
@@ -13,6 +13,7 @@ use Laminas\Paginator\Adapter\AdapterInterface;
 use Laminas\Paginator\AdapterPluginManager;
 use Laminas\Paginator\AdapterPluginManagerFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AdapterPluginManagerFactoryTest extends TestCase
@@ -37,8 +38,6 @@ class AdapterPluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
-     *
-     * @return void
      */
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
@@ -65,8 +64,6 @@ class AdapterPluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
-     *
-     * @return void
      */
     public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
     {
@@ -120,12 +117,12 @@ class AdapterPluginManagerFactoryTest extends TestCase
     {
         $paginator = $this->createMock(AdapterInterface::class);
 
-        /** @psalm-var callable(ContainerInterface):\PHPUnit\Framework\MockObject\MockObject&AdapterInterface $factory */
-        $factory   = function (ContainerInterface $container) use ($paginator): AdapterInterface {
+        /** @psalm-var callable(ContainerInterface ): MockObject&AdapterInterface $factory */
+        $factory = function (ContainerInterface $container) use ($paginator): AdapterInterface {
             return $paginator;
         };
 
-        $config    = [
+        $config = [
             'paginators' => [
                 'aliases'   => [
                     'test' => 'test-too',

--- a/test/AdapterPluginManagerFactoryTest.php
+++ b/test/AdapterPluginManagerFactoryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class AdapterPluginManagerFactoryTest extends TestCase
 {
-    public function testFactoryReturnsPluginManager()
+    public function testFactoryReturnsPluginManager(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $container
@@ -37,8 +37,10 @@ class AdapterPluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
+     *
+     * @return void
      */
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $container
@@ -63,8 +65,10 @@ class AdapterPluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
+     *
+     * @return void
      */
-    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
         $container
@@ -89,7 +93,7 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $this->assertSame($adapter, $adapters->get('test'));
     }
 
-    public function testDoesNotConfigureAdditionalPaginatorsWhenConfigServiceDoesNotContainPaginatorsConfig()
+    public function testDoesNotConfigureAdditionalPaginatorsWhenConfigServiceDoesNotContainPaginatorsConfig(): void
     {
         $container = $this->createMock(ContainerInterface::class);
 
@@ -112,18 +116,22 @@ class AdapterPluginManagerFactoryTest extends TestCase
         $this->assertFalse($adapters->has('foo'));
     }
 
-    public function testConfiguresPaginatorServicesWhenFound()
+    public function testConfiguresPaginatorServicesWhenFound(): void
     {
         $paginator = $this->createMock(AdapterInterface::class);
+
+        /** @psalm-var callable(ContainerInterface):\PHPUnit\Framework\MockObject\MockObject&AdapterInterface $factory */
+        $factory   = function (ContainerInterface $container) use ($paginator): AdapterInterface {
+            return $paginator;
+        };
+
         $config    = [
             'paginators' => [
                 'aliases'   => [
                     'test' => 'test-too',
                 ],
                 'factories' => [
-                    'test-too' => function ($container) use ($paginator) {
-                        return $paginator;
-                    },
+                    'test-too' => $factory,
                 ],
             ],
         ];

--- a/test/AdapterPluginManagerTest.php
+++ b/test/AdapterPluginManagerTest.php
@@ -59,7 +59,7 @@ class AdapterPluginManagerTest extends TestCase
         );
     }
 
-    public function testCanRetrieveAdapterPlugin()
+    public function testCanRetrieveAdapterPlugin(): void
     {
         $plugin = $this->adapterPluginManager->get('array', [1, 2, 3]);
         $this->assertInstanceOf(Adapter\ArrayAdapter::class, $plugin);
@@ -98,10 +98,15 @@ class AdapterPluginManagerTest extends TestCase
         $this->assertInstanceOf(Adapter\DbTableGateway::class, $plugin);
 
         // Test Callback
-        $itemsCallback = function () {
+        $itemsCallback = /**
+         * @return array
+         *
+         * @psalm-return array<empty, empty>
+         */
+        function (): array {
             return [];
         };
-        $countCallback = function () {
+        $countCallback = function (): int {
             return 0;
         };
 
@@ -109,7 +114,7 @@ class AdapterPluginManagerTest extends TestCase
         $this->assertInstanceOf(Adapter\Callback::class, $plugin);
     }
 
-    public function testFactoryCreatedDbSelectCanUseCustomCountSelect()
+    public function testFactoryCreatedDbSelectCanUseCustomCountSelect(): void
     {
         $mockSelect      = $this->createMock(Select::class);
         $mockSelectCount = $this->createMock(Select::class);

--- a/test/AdapterPluginManagerTest.php
+++ b/test/AdapterPluginManagerTest.php
@@ -99,9 +99,8 @@ class AdapterPluginManagerTest extends TestCase
 
         // Test Callback
         $itemsCallback = /**
-         * @return array
-         *
-         * @psalm-return array<empty, empty>
+        $itemsCallback =  * @return array
+        $itemsCallback =  * @psalm-return array<empty, empty>
          */
         function (): array {
             return [];

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -56,7 +56,7 @@ class FactoryTest extends TestCase
         );
     }
 
-    public function testCanFactoryPaginatorWithStringAdapterObject()
+    public function testCanFactoryPaginatorWithStringAdapterObject(): void
     {
         $datas     = [1, 2, 3];
         $paginator = Paginator\Factory::factory($datas, new Adapter\ArrayAdapter($datas));
@@ -64,7 +64,7 @@ class FactoryTest extends TestCase
         $this->assertEquals(count($datas), $paginator->getCurrentItemCount());
     }
 
-    public function testCanFactoryPaginatorWithStringAdapterName()
+    public function testCanFactoryPaginatorWithStringAdapterName(): void
     {
         $datas     = [1, 2, 3];
         $paginator = Paginator\Factory::factory($datas, 'array');
@@ -72,19 +72,19 @@ class FactoryTest extends TestCase
         $this->assertEquals(count($datas), $paginator->getCurrentItemCount());
     }
 
-    public function testCanFactoryPaginatorWithStringAdapterAggregate()
+    public function testCanFactoryPaginatorWithStringAdapterAggregate(): void
     {
         $paginator = Paginator\Factory::factory(null, new TestArrayAggregate());
         $this->assertInstanceOf(ArrayAdapter::class, $paginator->getAdapter());
     }
 
-    public function testCanFactoryPaginatorWithDbSelect()
+    public function testCanFactoryPaginatorWithDbSelect(): void
     {
         $paginator = Paginator\Factory::factory([$this->mockSelect, $this->mockAdapter], 'dbselect');
         $this->assertInstanceOf(DbSelect::class, $paginator->getAdapter());
     }
 
-    public function testCanFactoryPaginatorWithOneParameterWithArrayAdapter()
+    public function testCanFactoryPaginatorWithOneParameterWithArrayAdapter(): void
     {
         $datas     = [
             'items'   => [1, 2, 3],
@@ -95,7 +95,7 @@ class FactoryTest extends TestCase
         $this->assertEquals(count($datas['items']), $paginator->getCurrentItemCount());
     }
 
-    public function testCanFactoryPaginatorWithOneParameterWithDbAdapter()
+    public function testCanFactoryPaginatorWithOneParameterWithDbAdapter(): void
     {
         $datas     = [
             'items'   => [$this->mockSelect, $this->mockAdapter],
@@ -105,7 +105,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(DbSelect::class, $paginator->getAdapter());
     }
 
-    public function testCanFactoryPaginatorWithOneBadParameter()
+    public function testCanFactoryPaginatorWithOneBadParameter(): void
     {
         $datas = [
             [1, 2, 3],

--- a/test/PaginatorIteratorTest.php
+++ b/test/PaginatorIteratorTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class PaginatorIteratorTest extends TestCase
 {
-    public function testIteratorFlattensPaginator()
+    public function testIteratorFlattensPaginator(): void
     {
         $paginator = new Paginator(
             new ArrayAdapter(['foo', 'bar', 'fiz'])
@@ -41,7 +41,7 @@ class PaginatorIteratorTest extends TestCase
         $this->assertFalse($iterator->valid());
     }
 
-    public function testIteratorReturnsInvalidOnEmptyIterator()
+    public function testIteratorReturnsInvalidOnEmptyIterator(): void
     {
         $paginator = new Paginator(
             new ArrayAdapter([])

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -108,7 +108,7 @@ class PaginatorTest extends TestCase
     }
 
     // @codingStandardsIgnoreStart
-    protected function _getTmpDir()
+    protected function _getTmpDir(): string
     {
         // @codingStandardsIgnoreEnd
         $tmpDir = rtrim(sys_get_temp_dir(), '/\\') . DIRECTORY_SEPARATOR . 'laminas_paginator';
@@ -121,7 +121,7 @@ class PaginatorTest extends TestCase
     }
 
     // @codingStandardsIgnoreStart
-    protected function _rmDirRecursive($path)
+    protected function _rmDirRecursive(string $path): void
     {
         // @codingStandardsIgnoreEnd
         $dir = new DirectoryIterator($path);
@@ -140,7 +140,7 @@ class PaginatorTest extends TestCase
     }
 
     // @codingStandardsIgnoreStart
-    protected function _restorePaginatorDefaults()
+    protected function _restorePaginatorDefaults(): void
     {
         // @codingStandardsIgnoreEnd
         $this->paginator->setItemCountPerPage(10);
@@ -160,7 +160,7 @@ class PaginatorTest extends TestCase
         $this->paginator->setCacheEnabled(true);
     }
 
-    public function testGetsAndSetsDefaultScrollingStyle()
+    public function testGetsAndSetsDefaultScrollingStyle(): void
     {
         $this->assertEquals(Paginator\Paginator::getDefaultScrollingStyle(), 'Sliding');
         Paginator\Paginator::setDefaultScrollingStyle('Scrolling');
@@ -168,19 +168,19 @@ class PaginatorTest extends TestCase
         Paginator\Paginator::setDefaultScrollingStyle('Sliding');
     }
 
-    public function testHasCorrectCountAfterInit()
+    public function testHasCorrectCountAfterInit(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
         $this->assertEquals(11, $paginator->count());
     }
 
-    public function testHasCorrectCountOfAllItemsAfterInit()
+    public function testHasCorrectCountOfAllItemsAfterInit(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
         $this->assertEquals(101, $paginator->getTotalItemCount());
     }
 
-    public function testRepetitiveCallOfCountResultsOfZero()
+    public function testRepetitiveCallOfCountResultsOfZero(): void
     {
         $count = 0;
 
@@ -197,7 +197,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($count, $paginator->count());
     }
 
-    public function testLoadsFromConfig()
+    public function testLoadsFromConfig(): void
     {
         Paginator\Paginator::setGlobalConfig($this->config->testing);
         $this->assertEquals('Scrolling', Paginator\Paginator::getDefaultScrollingStyle());
@@ -210,7 +210,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals(7, $paginator->getPageRange());
     }
 
-    public function testGetsPagesForPageOne()
+    public function testGetsPagesForPageOne(): void
     {
         $expected                   = new stdClass();
         $expected->pageCount        = 11;
@@ -232,7 +232,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesForPageTwo()
+    public function testGetsPagesForPageTwo(): void
     {
         $expected                   = new stdClass();
         $expected->pageCount        = 11;
@@ -256,14 +256,14 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testRendersWithoutPartial()
+    public function testRendersWithoutPartial(): void
     {
         $this->paginator->setView(new View\Renderer\PhpRenderer());
         $string = @$this->paginator->__toString();
         $this->assertEquals('', $string);
     }
 
-    public function testRendersWithPartial()
+    public function testRendersWithPartial(): void
     {
         $view = new View\Renderer\PhpRenderer();
         $view->resolver()->addPath(__DIR__ . '/_files/scripts');
@@ -276,12 +276,12 @@ class PaginatorTest extends TestCase
         $this->assertEquals('partial rendered successfully', $string);
     }
 
-    public function testGetsPageCount()
+    public function testGetsPageCount(): void
     {
         $this->assertEquals(11, $this->paginator->count());
     }
 
-    public function testGetsAndSetsItemCountPerPage()
+    public function testGetsAndSetsItemCountPerPage(): void
     {
         Paginator\Paginator::setGlobalConfig(new Config\Config([]));
         $this->paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
@@ -295,8 +295,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5376
+     *
+     * @return void
      */
-    public function testGetsAndSetsItemCounterPerPageOfNegativeOne()
+    public function testGetsAndSetsItemCounterPerPageOfNegativeOne(): void
     {
         Paginator\Paginator::setGlobalConfig(new Config\Config([]));
         $this->paginator = new Paginator\Paginator(new Paginator\Adapter\ArrayAdapter(range(1, 101)));
@@ -307,8 +309,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5376
+     *
+     * @return void
      */
-    public function testGetsAndSetsItemCounterPerPageOfZero()
+    public function testGetsAndSetsItemCounterPerPageOfZero(): void
     {
         Paginator\Paginator::setGlobalConfig(new Config\Config([]));
         $this->paginator = new Paginator\Paginator(new Paginator\Adapter\ArrayAdapter(range(1, 101)));
@@ -319,8 +323,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5376
+     *
+     * @return void
      */
-    public function testGetsAndSetsItemCounterPerPageOfNull()
+    public function testGetsAndSetsItemCounterPerPageOfNull(): void
     {
         Paginator\Paginator::setGlobalConfig(new Config\Config([]));
         $this->paginator = new Paginator\Paginator(new Paginator\Adapter\ArrayAdapter(range(1, 101)));
@@ -329,7 +335,7 @@ class PaginatorTest extends TestCase
         $this->paginator->setItemCountPerPage(10);
     }
 
-    public function testGetsCurrentItemCount()
+    public function testGetsCurrentItemCount(): void
     {
         $this->paginator->setItemCountPerPage(10);
         $this->paginator->setPageRange(10);
@@ -343,7 +349,7 @@ class PaginatorTest extends TestCase
         $this->paginator->setCurrentPageNumber(1);
     }
 
-    public function testGetsCurrentItems()
+    public function testGetsCurrentItems(): void
     {
         $items = $this->paginator->getCurrentItems();
         $this->assertInstanceOf(ArrayIterator::class, $items);
@@ -357,7 +363,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals(10, $count);
     }
 
-    public function testGetsIterator()
+    public function testGetsIterator(): void
     {
         $items = $this->paginator->getIterator();
         $this->assertInstanceOf('ArrayIterator', $items);
@@ -371,7 +377,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals(10, $count);
     }
 
-    public function testGetsAndSetsCurrentPageNumber()
+    public function testGetsAndSetsCurrentPageNumber(): void
     {
         $this->assertEquals(1, $this->paginator->getCurrentPageNumber());
         $this->paginator->setCurrentPageNumber(-1);
@@ -384,21 +390,21 @@ class PaginatorTest extends TestCase
         $this->assertEquals(1, $this->paginator->getCurrentPageNumber());
     }
 
-    public function testGetsAbsoluteItemNumber()
+    public function testGetsAbsoluteItemNumber(): void
     {
         $this->assertEquals(1, $this->paginator->getAbsoluteItemNumber(1));
         $this->assertEquals(11, $this->paginator->getAbsoluteItemNumber(1, 2));
         $this->assertEquals(24, $this->paginator->getAbsoluteItemNumber(4, 3));
     }
 
-    public function testGetsItem()
+    public function testGetsItem(): void
     {
         $this->assertEquals(1, $this->paginator->getItem(1));
         $this->assertEquals(11, $this->paginator->getItem(1, 2));
         $this->assertEquals(24, $this->paginator->getItem(4, 3));
     }
 
-    public function testThrowsExceptionWhenCollectionIsEmpty()
+    public function testThrowsExceptionWhenCollectionIsEmpty(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter([]));
 
@@ -407,14 +413,14 @@ class PaginatorTest extends TestCase
         $paginator->getItem(1);
     }
 
-    public function testThrowsExceptionWhenRetrievingNonexistentItemFromLastPage()
+    public function testThrowsExceptionWhenRetrievingNonexistentItemFromLastPage(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Page 11 does not contain item number 10');
         $this->paginator->getItem(10, 11);
     }
 
-    public function testNormalizesPageNumber()
+    public function testNormalizesPageNumber(): void
     {
         $this->assertEquals(1, $this->paginator->normalizePageNumber(0));
         $this->assertEquals(1, $this->paginator->normalizePageNumber(1));
@@ -425,7 +431,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals(11, $this->paginator->normalizePageNumber(12));
     }
 
-    public function testNormalizesItemNumber()
+    public function testNormalizesItemNumber(): void
     {
         $this->assertEquals(1, $this->paginator->normalizeItemNumber(0));
         $this->assertEquals(1, $this->paginator->normalizeItemNumber(1));
@@ -438,8 +444,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-8656
+     *
+     * @return void
      */
-    public function testNormalizesPageNumberWhenGivenAFloat()
+    public function testNormalizesPageNumberWhenGivenAFloat(): void
     {
         $this->assertEquals(1, $this->paginator->normalizePageNumber(0.5));
         $this->assertEquals(1, $this->paginator->normalizePageNumber(1.99));
@@ -452,8 +460,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-8656
+     *
+     * @return void
      */
-    public function testNormalizesItemNumberWhenGivenAFloat()
+    public function testNormalizesItemNumberWhenGivenAFloat(): void
     {
         $this->assertEquals(1, $this->paginator->normalizeItemNumber(0.5));
         $this->assertEquals(1, $this->paginator->normalizeItemNumber(1.99));
@@ -464,19 +474,19 @@ class PaginatorTest extends TestCase
         $this->assertEquals(10, $this->paginator->normalizeItemNumber(11.7889));
     }
 
-    public function testGetsPagesInSubsetRange()
+    public function testGetsPagesInSubsetRange(): void
     {
         $actual = $this->paginator->getPagesInRange(3, 8);
         $this->assertEquals(array_combine(range(3, 8), range(3, 8)), $actual);
     }
 
-    public function testGetsPagesInOutOfBoundsRange()
+    public function testGetsPagesInOutOfBoundsRange(): void
     {
         $actual = $this->paginator->getPagesInRange(-1, 12);
         $this->assertEquals(array_combine(range(1, 11), range(1, 11)), $actual);
     }
 
-    public function testGetsItemsByPage()
+    public function testGetsItemsByPage(): void
     {
         $expected = new ArrayIterator(range(1, 10));
 
@@ -489,8 +499,10 @@ class PaginatorTest extends TestCase
     /**
      * @group 6817
      * @group 6812
+     *
+     * @return void
      */
-    public function testGetsItemsByPageHandleDbSelectAdapter()
+    public function testGetsItemsByPageHandleDbSelectAdapter(): void
     {
         $resultSet = new ResultSet();
         $result    = $this->createMock(ResultInterface::class);
@@ -540,7 +552,7 @@ class PaginatorTest extends TestCase
         }
     }
 
-    public function testGetsItemCount()
+    public function testGetsItemCount(): void
     {
         $this->assertEquals(101, $this->paginator->getItemCount(range(1, 101)));
 
@@ -548,25 +560,25 @@ class PaginatorTest extends TestCase
         $this->assertEquals(101, $this->paginator->getItemCount($limitIterator));
     }
 
-    public function testGeneratesViewIfNonexistent()
+    public function testGeneratesViewIfNonexistent(): void
     {
         $this->assertInstanceOf(RendererInterface::class, $this->paginator->getView());
     }
 
-    public function testGetsAndSetsView()
+    public function testGetsAndSetsView(): void
     {
         $this->paginator->setView(new View\Renderer\PhpRenderer());
         $this->assertInstanceOf(RendererInterface::class, $this->paginator->getView());
     }
 
-    public function testRenders()
+    public function testRenders(): void
     {
         $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage('view partial');
         $this->paginator->render(new View\Renderer\PhpRenderer());
     }
 
-    public function testGetsAndSetsPageRange()
+    public function testGetsAndSetsPageRange(): void
     {
         $this->assertEquals(10, $this->paginator->getPageRange());
         $this->paginator->setPageRange(15);
@@ -575,8 +587,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-3720
+     *
+     * @return void
      */
-    public function testGivesCorrectItemCount()
+    public function testGivesCorrectItemCount(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
         $paginator->setCurrentPageNumber(5)
@@ -588,8 +602,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-3737
+     *
+     * @return void
      */
-    public function testKeepsCurrentPageNumberAfterItemCountPerPageSet()
+    public function testKeepsCurrentPageNumberAfterItemCountPerPageSet(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(['item1', 'item2']));
         $paginator->setCurrentPageNumber(2)
@@ -602,8 +618,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-4193
+     *
+     * @return void
      */
-    public function testCastsIntegerValuesToInteger()
+    public function testCastsIntegerValuesToInteger(): void
     {
         // Current page number
         $this->paginator->setCurrentPageNumber(3.3);
@@ -620,14 +638,16 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-4207
+     *
+     * @return void
      */
-    public function testAcceptsTraversableInstanceFromAdapter()
+    public function testAcceptsTraversableInstanceFromAdapter(): void
     {
         $paginator = new Paginator\Paginator(new TestAsset\TestAdapter());
         $this->assertInstanceOf('ArrayObject', $paginator->getCurrentItems());
     }
 
-    public function testCachedItem()
+    public function testCachedItem(): void
     {
         $this->paginator->setCurrentPageNumber(1)->getCurrentItems();
         $this->paginator->setCurrentPageNumber(2)->getCurrentItems();
@@ -645,7 +665,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $pageItems);
     }
 
-    public function testClearPageItemCache()
+    public function testClearPageItemCache(): void
     {
         $this->paginator->setCurrentPageNumber(1)->getCurrentItems();
         $this->paginator->setCurrentPageNumber(2)->getCurrentItems();
@@ -672,7 +692,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals(42, $this->cache->getItem('not_paginator_item'));
     }
 
-    public function testWithCacheDisabled()
+    public function testWithCacheDisabled(): void
     {
         $this->paginator->setCacheEnabled(false);
         $this->paginator->setCurrentPageNumber(1)->getCurrentItems();
@@ -687,7 +707,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected, $pageItems);
     }
 
-    public function testCacheDoesNotDisturbResultsWhenChangingParam()
+    public function testCacheDoesNotDisturbResultsWhenChangingParam(): void
     {
         $this->paginator->setCurrentPageNumber(1)->getCurrentItems();
         $pageItems = $this->paginator->setItemCountPerPage(5)->getCurrentItems();
@@ -717,7 +737,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($expected[2], $pageItems[2]);
     }
 
-    public function testToJson()
+    public function testToJson(): void
     {
         $this->paginator->setCurrentPageNumber(1);
 
@@ -728,7 +748,7 @@ class PaginatorTest extends TestCase
         $this->assertStringContainsString($expected, $json);
     }
 
-    public function testFilter()
+    public function testFilter(): void
     {
         $filter    = new Filter\Callback([$this, 'filterCallback']);
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
@@ -755,8 +775,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5785
+     *
+     * @return void
      */
-    public function testGetSetDefaultItemCountPerPage()
+    public function testGetSetDefaultItemCountPerPage(): void
     {
         Paginator\Paginator::setGlobalConfig(new Config\Config([]));
 
@@ -774,8 +796,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7207
+     *
+     * @return void
      */
-    public function testItemCountPerPageByDefault()
+    public function testItemCountPerPageByDefault(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 20)));
         $this->assertEquals(2, $paginator->count());
@@ -783,8 +807,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5427
+     *
+     * @return void
      */
-    public function testNegativeItemNumbers()
+    public function testNegativeItemNumbers(): void
     {
         $this->assertEquals(10, $this->paginator->getItem(-1, 1));
         $this->assertEquals(9, $this->paginator->getItem(-2, 1));
@@ -793,8 +819,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7602
+     *
+     * @return void
      */
-    public function testAcceptAndHandlePaginatorAdapterAggregateDataInFactory()
+    public function testAcceptAndHandlePaginatorAdapterAggregateDataInFactory(): void
     {
         $p = new Paginator\Paginator(new TestArrayAggregate());
 
@@ -805,8 +833,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7602
+     *
+     * @return void
      */
-    public function testAcceptAndHandlePaginatorAdapterAggregateInConstructor()
+    public function testAcceptAndHandlePaginatorAdapterAggregateInConstructor(): void
     {
         $p = new Paginator\Paginator(new TestArrayAggregate());
 
@@ -817,9 +847,10 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7602
+     *
+     * @return void
      */
-    // @codingStandardsIgnoreStart
-    public function testInvalidDataInConstructor_ThrowsException()
+    public function testInvalidDataInConstructorThrowsException(): void
     {
         // @codingStandardsIgnoreEnd
         $this->expectException(\Laminas\Paginator\Exception\ExceptionInterface::class);
@@ -829,14 +860,17 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-9396
+     *
+     * @return void
      */
-    public function testArrayAccessInClassSerializableLimitIterator()
+    public function testArrayAccessInClassSerializableLimitIterator(): void
     {
         $iterator  = new ArrayIterator(['laminas9396', 'foo', null]);
         $paginator = new Paginator\Paginator(new Adapter\Iterator($iterator));
 
         $this->assertEquals('laminas9396', $paginator->getItem(1));
 
+        /** @psalm-var \Laminas\Paginator\SerializableLimitIterator $items */
         $items = $paginator->getAdapter()
                            ->getItems(0, 10);
 
@@ -847,7 +881,7 @@ class PaginatorTest extends TestCase
         $this->assertFalse(isset($items[3]));
     }
 
-    public function testSetGlobalConfigThrowsInvalidArgumentException()
+    public function testSetGlobalConfigThrowsInvalidArgumentException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('setGlobalConfig expects an array or Traversable');
@@ -855,7 +889,7 @@ class PaginatorTest extends TestCase
         $this->paginator->setGlobalConfig('not array');
     }
 
-    public function testSetScrollingStylePluginManagerWithStringThrowsInvalidArgumentException()
+    public function testSetScrollingStylePluginManagerWithStringThrowsInvalidArgumentException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -865,7 +899,7 @@ class PaginatorTest extends TestCase
         $this->paginator->setScrollingStylePluginManager('invalid adapter');
     }
 
-    public function testSetScrollingStylePluginManagerWithAdapterThrowsInvalidArgumentException()
+    public function testSetScrollingStylePluginManagerWithAdapterThrowsInvalidArgumentException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -877,7 +911,7 @@ class PaginatorTest extends TestCase
         );
     }
 
-    public function testLoadScrollingStyleWithDigitThrowsInvalidArgumentException()
+    public function testLoadScrollingStyleWithDigitThrowsInvalidArgumentException(): void
     {
         $adapter    = new TestAsset\TestAdapter();
         $paginator  = new Paginator\Paginator($adapter);
@@ -893,7 +927,7 @@ class PaginatorTest extends TestCase
         $reflection->invoke($paginator, 12345);
     }
 
-    public function testLoadScrollingStyleWithObjectThrowsInvalidArgumentException()
+    public function testLoadScrollingStyleWithObjectThrowsInvalidArgumentException(): void
     {
         $adapter    = new TestAsset\TestAdapter();
         $paginator  = new Paginator\Paginator($adapter);
@@ -908,7 +942,7 @@ class PaginatorTest extends TestCase
         $reflection->invoke($paginator, new stdClass());
     }
 
-    public function testGetCacheId()
+    public function testGetCacheId(): void
     {
         $adapter              = new TestAsset\TestAdapter();
         $paginator            = new Paginator\Paginator($adapter);
@@ -931,7 +965,7 @@ class PaginatorTest extends TestCase
         $this->assertEquals($outputGetCacheId, 'Laminas_Paginator_1_' . $outputGetCacheInternalId);
     }
 
-    public function testGetCacheIdWithSameAdapterAndDifferentAttributes()
+    public function testGetCacheIdWithSameAdapterAndDifferentAttributes(): void
     {
         $adapter   = new TestAsset\TestAdapter([1, 2, 3, 4]);
         $paginator = new Paginator\Paginator($adapter);
@@ -948,7 +982,7 @@ class PaginatorTest extends TestCase
         $this->assertNotEquals($firstOutputGetCacheInternalId, $secondOutputGetCacheInternalId);
     }
 
-    public function testGetCacheIdWithInheritedClass()
+    public function testGetCacheIdWithInheritedClass(): void
     {
         $adapter   = new TestAsset\TestAdapter([1, 2, 3, 4]);
         $paginator = new Paginator\Paginator($adapter);
@@ -965,7 +999,7 @@ class PaginatorTest extends TestCase
         $this->assertNotEquals($firstOutputGetCacheInternalId, $secondOutputGetCacheInternalId);
     }
 
-    public function testDbSelectAdapterShouldProduceValidCacheId()
+    public function testDbSelectAdapterShouldProduceValidCacheId(): void
     {
         // Create first interal cache ID
         $paginator                    = new Paginator\Paginator(
@@ -1015,7 +1049,7 @@ class PaginatorTest extends TestCase
         $this->assertNotEquals($firstCacheId, $secondCacheIde);
     }
 
-    public function testAcceptsComplexAdapters()
+    public function testAcceptsComplexAdapters(): void
     {
         $paginator = new Paginator\Paginator(
             new TestAsset\TestAdapter(function () {
@@ -1028,8 +1062,10 @@ class PaginatorTest extends TestCase
     /**
      * @group 6808
      * @group 6809
+     *
+     * @return void
      */
-    public function testItemCountsForEmptyItemSet()
+    public function testItemCountsForEmptyItemSet(): void
     {
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter([]));
         $paginator->setCurrentPageNumber(1);

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -30,6 +30,7 @@ use Laminas\Paginator\Adapter\ArrayAdapter;
 use Laminas\Paginator\Adapter\DbSelect;
 use Laminas\Paginator\Exception;
 use Laminas\Paginator\Exception\InvalidArgumentException;
+use Laminas\Paginator\SerializableLimitIterator;
 use Laminas\View;
 use Laminas\View\Exception\ExceptionInterface;
 use Laminas\View\Helper;
@@ -295,8 +296,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5376
-     *
-     * @return void
      */
     public function testGetsAndSetsItemCounterPerPageOfNegativeOne(): void
     {
@@ -309,8 +308,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5376
-     *
-     * @return void
      */
     public function testGetsAndSetsItemCounterPerPageOfZero(): void
     {
@@ -323,8 +320,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5376
-     *
-     * @return void
      */
     public function testGetsAndSetsItemCounterPerPageOfNull(): void
     {
@@ -444,8 +439,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-8656
-     *
-     * @return void
      */
     public function testNormalizesPageNumberWhenGivenAFloat(): void
     {
@@ -460,8 +453,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-8656
-     *
-     * @return void
      */
     public function testNormalizesItemNumberWhenGivenAFloat(): void
     {
@@ -499,8 +490,6 @@ class PaginatorTest extends TestCase
     /**
      * @group 6817
      * @group 6812
-     *
-     * @return void
      */
     public function testGetsItemsByPageHandleDbSelectAdapter(): void
     {
@@ -587,8 +576,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-3720
-     *
-     * @return void
      */
     public function testGivesCorrectItemCount(): void
     {
@@ -602,8 +589,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-3737
-     *
-     * @return void
      */
     public function testKeepsCurrentPageNumberAfterItemCountPerPageSet(): void
     {
@@ -618,8 +603,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-4193
-     *
-     * @return void
      */
     public function testCastsIntegerValuesToInteger(): void
     {
@@ -638,8 +621,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-4207
-     *
-     * @return void
      */
     public function testAcceptsTraversableInstanceFromAdapter(): void
     {
@@ -775,8 +756,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5785
-     *
-     * @return void
      */
     public function testGetSetDefaultItemCountPerPage(): void
     {
@@ -796,8 +775,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7207
-     *
-     * @return void
      */
     public function testItemCountPerPageByDefault(): void
     {
@@ -807,8 +784,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-5427
-     *
-     * @return void
      */
     public function testNegativeItemNumbers(): void
     {
@@ -819,8 +794,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7602
-     *
-     * @return void
      */
     public function testAcceptAndHandlePaginatorAdapterAggregateDataInFactory(): void
     {
@@ -833,8 +806,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7602
-     *
-     * @return void
      */
     public function testAcceptAndHandlePaginatorAdapterAggregateInConstructor(): void
     {
@@ -847,8 +818,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-7602
-     *
-     * @return void
      */
     public function testInvalidDataInConstructorThrowsException(): void
     {
@@ -860,8 +829,6 @@ class PaginatorTest extends TestCase
 
     /**
      * @group Laminas-9396
-     *
-     * @return void
      */
     public function testArrayAccessInClassSerializableLimitIterator(): void
     {
@@ -870,7 +837,7 @@ class PaginatorTest extends TestCase
 
         $this->assertEquals('laminas9396', $paginator->getItem(1));
 
-        /** @psalm-var \Laminas\Paginator\SerializableLimitIterator $items */
+        /** @psalm-var SerializableLimitIterator $items */
         $items = $paginator->getAdapter()
                            ->getItems(0, 10);
 
@@ -1062,8 +1029,6 @@ class PaginatorTest extends TestCase
     /**
      * @group 6808
      * @group 6809
-     *
-     * @return void
      */
     public function testItemCountsForEmptyItemSet(): void
     {

--- a/test/ScrollingStyle/AllTest.php
+++ b/test/ScrollingStyle/AllTest.php
@@ -49,14 +49,14 @@ class AllTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsPages()
+    public function testGetsPages(): void
     {
         $expected = array_combine(range(1, 11), range(1, 11));
         $pages    = $this->scrollingStyle->getPages($this->paginator);
         $this->assertEquals($expected, $pages);
     }
 
-    public function testGetsNextAndPreviousPageForFirstPage()
+    public function testGetsNextAndPreviousPageForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $pages = $this->paginator->getPages('All');
@@ -64,7 +64,7 @@ class AllTest extends TestCase
         $this->assertEquals(2, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondPage()
+    public function testGetsNextAndPreviousPageForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $pages = $this->paginator->getPages('All');
@@ -72,7 +72,7 @@ class AllTest extends TestCase
         $this->assertEquals(3, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForMiddlePage()
+    public function testGetsNextAndPreviousPageForMiddlePage(): void
     {
         $this->paginator->setCurrentPageNumber(6);
         $pages = $this->paginator->getPages('All');
@@ -80,7 +80,7 @@ class AllTest extends TestCase
         $this->assertEquals(7, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondLastPage()
+    public function testGetsNextAndPreviousPageForSecondLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(10);
         $pages = $this->paginator->getPages('All');
@@ -88,7 +88,7 @@ class AllTest extends TestCase
         $this->assertEquals(11, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForLastPage()
+    public function testGetsNextAndPreviousPageForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(11);
         $pages = $this->paginator->getPages('All');

--- a/test/ScrollingStyle/ElasticTest.php
+++ b/test/ScrollingStyle/ElasticTest.php
@@ -50,7 +50,7 @@ class ElasticTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsPagesInRangeForFirstPage()
+    public function testGetsPagesInRangeForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $actual   = $this->scrollingStyle->getPages($this->paginator);
@@ -58,7 +58,7 @@ class ElasticTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesInRangeForSecondPage()
+    public function testGetsPagesInRangeForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $actual   = $this->scrollingStyle->getPages($this->paginator);
@@ -66,7 +66,7 @@ class ElasticTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesInRangeForTenthPage()
+    public function testGetsPagesInRangeForTenthPage(): void
     {
         $this->paginator->setCurrentPageNumber(10);
         $actual   = $this->scrollingStyle->getPages($this->paginator);
@@ -74,7 +74,7 @@ class ElasticTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesInRangeForLastPage()
+    public function testGetsPagesInRangeForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(21);
         $actual   = $this->scrollingStyle->getPages($this->paginator);
@@ -82,7 +82,7 @@ class ElasticTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsNextAndPreviousPageForFirstPage()
+    public function testGetsNextAndPreviousPageForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $pages = $this->paginator->getPages('Elastic');
@@ -90,7 +90,7 @@ class ElasticTest extends TestCase
         $this->assertEquals(2, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondPage()
+    public function testGetsNextAndPreviousPageForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $pages = $this->paginator->getPages('Elastic');
@@ -98,7 +98,7 @@ class ElasticTest extends TestCase
         $this->assertEquals(3, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForMiddlePage()
+    public function testGetsNextAndPreviousPageForMiddlePage(): void
     {
         $this->paginator->setCurrentPageNumber(10);
         $pages = $this->paginator->getPages('Elastic');
@@ -106,7 +106,7 @@ class ElasticTest extends TestCase
         $this->assertEquals(11, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondLastPage()
+    public function testGetsNextAndPreviousPageForSecondLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(20);
         $pages = $this->paginator->getPages('Elastic');
@@ -114,14 +114,14 @@ class ElasticTest extends TestCase
         $this->assertEquals(21, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForLastPage()
+    public function testGetsNextAndPreviousPageForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(21);
         $pages = $this->paginator->getPages('Elastic');
         $this->assertEquals(20, $pages->previous);
     }
 
-    public function testNoPagesOnLastPageEqualsPageRange()
+    public function testNoPagesOnLastPageEqualsPageRange(): void
     {
         $this->paginator->setPageRange(3);
         $this->paginator->setCurrentPageNumber(21);
@@ -129,7 +129,7 @@ class ElasticTest extends TestCase
         $this->assertEquals(3, count($pages->pagesInRange));
     }
 
-    public function testNoPagesOnSecondLastPageEqualsPageRangeMinOne()
+    public function testNoPagesOnSecondLastPageEqualsPageRangeMinOne(): void
     {
         $this->paginator->setPageRange(3);
         $this->paginator->setCurrentPageNumber(20);
@@ -137,7 +137,7 @@ class ElasticTest extends TestCase
         $this->assertEquals(4, count($pages->pagesInRange));
     }
 
-    public function testNoPagesBeforeSecondLastPageEqualsPageRangeMinTwo()
+    public function testNoPagesBeforeSecondLastPageEqualsPageRangeMinTwo(): void
     {
         $this->paginator->setPageRange(3);
         $this->paginator->setCurrentPageNumber(19);

--- a/test/ScrollingStyle/JumpingTest.php
+++ b/test/ScrollingStyle/JumpingTest.php
@@ -54,28 +54,28 @@ class JumpingTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsPagesInRangeForFirstPage()
+    public function testGetsPagesInRangeForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $actual = $this->scrollingStyle->getPages($this->paginator);
         $this->assertEquals($this->expectedRange, $actual);
     }
 
-    public function testGetsPagesInRangeForSecondPage()
+    public function testGetsPagesInRangeForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $actual = $this->scrollingStyle->getPages($this->paginator);
         $this->assertEquals($this->expectedRange, $actual);
     }
 
-    public function testGetsPagesInRangeForSecondLastPage()
+    public function testGetsPagesInRangeForSecondLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(10);
         $actual = $this->scrollingStyle->getPages($this->paginator);
         $this->assertEquals($this->expectedRange, $actual);
     }
 
-    public function testGetsPagesInRangeForLastPage()
+    public function testGetsPagesInRangeForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(11);
         $actual   = $this->scrollingStyle->getPages($this->paginator);
@@ -83,7 +83,7 @@ class JumpingTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsNextAndPreviousPageForFirstPage()
+    public function testGetsNextAndPreviousPageForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $pages = $this->paginator->getPages('Jumping');
@@ -91,7 +91,7 @@ class JumpingTest extends TestCase
         $this->assertEquals(2, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondPage()
+    public function testGetsNextAndPreviousPageForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $pages = $this->paginator->getPages('Jumping');
@@ -99,7 +99,7 @@ class JumpingTest extends TestCase
         $this->assertEquals(3, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForMiddlePage()
+    public function testGetsNextAndPreviousPageForMiddlePage(): void
     {
         $this->paginator->setCurrentPageNumber(6);
         $pages = $this->paginator->getPages('Jumping');
@@ -107,7 +107,7 @@ class JumpingTest extends TestCase
         $this->assertEquals(7, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondLastPage()
+    public function testGetsNextAndPreviousPageForSecondLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(10);
         $pages = $this->paginator->getPages('Jumping');
@@ -115,7 +115,7 @@ class JumpingTest extends TestCase
         $this->assertEquals(11, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForLastPage()
+    public function testGetsNextAndPreviousPageForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(11);
         $pages = $this->paginator->getPages('Jumping');

--- a/test/ScrollingStyle/SlidingTest.php
+++ b/test/ScrollingStyle/SlidingTest.php
@@ -54,7 +54,7 @@ class SlidingTest extends TestCase
         parent::tearDown();
     }
 
-    public function testGetsPagesInRangeForFirstPage()
+    public function testGetsPagesInRangeForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $actual   = $this->_scrollingStyle->getPages($this->paginator);
@@ -62,7 +62,7 @@ class SlidingTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesInRangeForSecondPage()
+    public function testGetsPagesInRangeForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $actual   = $this->_scrollingStyle->getPages($this->paginator);
@@ -70,7 +70,7 @@ class SlidingTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesInRangeForFifthPage()
+    public function testGetsPagesInRangeForFifthPage(): void
     {
         $this->paginator->setCurrentPageNumber(5);
         $actual   = $this->_scrollingStyle->getPages($this->paginator);
@@ -78,7 +78,7 @@ class SlidingTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsPagesInRangeForLastPage()
+    public function testGetsPagesInRangeForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(11);
         $actual   = $this->_scrollingStyle->getPages($this->paginator);
@@ -86,7 +86,7 @@ class SlidingTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testGetsNextAndPreviousPageForFirstPage()
+    public function testGetsNextAndPreviousPageForFirstPage(): void
     {
         $this->paginator->setCurrentPageNumber(1);
         $pages = $this->paginator->getPages('Sliding');
@@ -94,7 +94,7 @@ class SlidingTest extends TestCase
         $this->assertEquals(2, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondPage()
+    public function testGetsNextAndPreviousPageForSecondPage(): void
     {
         $this->paginator->setCurrentPageNumber(2);
         $pages = $this->paginator->getPages('Sliding');
@@ -102,7 +102,7 @@ class SlidingTest extends TestCase
         $this->assertEquals(3, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForMiddlePage()
+    public function testGetsNextAndPreviousPageForMiddlePage(): void
     {
         $this->paginator->setCurrentPageNumber(6);
         $pages = $this->paginator->getPages('Sliding');
@@ -110,7 +110,7 @@ class SlidingTest extends TestCase
         $this->assertEquals(7, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForSecondLastPage()
+    public function testGetsNextAndPreviousPageForSecondLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(10);
         $pages = $this->paginator->getPages('Sliding');
@@ -118,14 +118,14 @@ class SlidingTest extends TestCase
         $this->assertEquals(11, $pages->next);
     }
 
-    public function testGetsNextAndPreviousPageForLastPage()
+    public function testGetsNextAndPreviousPageForLastPage(): void
     {
         $this->paginator->setCurrentPageNumber(11);
         $pages = $this->paginator->getPages('Sliding');
         $this->assertEquals(10, $pages->previous);
     }
 
-    public function testAcceptsPageRangeLargerThanPageCount()
+    public function testAcceptsPageRangeLargerThanPageCount(): void
     {
         $this->paginator->setPageRange(100);
         $pages = $this->paginator->getPages();

--- a/test/ScrollingStylePluginManagerFactoryTest.php
+++ b/test/ScrollingStylePluginManagerFactoryTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class ScrollingStylePluginManagerFactoryTest extends TestCase
 {
-    public function testFactoryReturnsPluginManager()
+    public function testFactoryReturnsPluginManager(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $factory   = new ScrollingStylePluginManagerFactory();
@@ -28,8 +28,10 @@ class ScrollingStylePluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
+     *
+     * @return void
      */
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $container      = $this->createMock(ContainerInterface::class);
         $scrollingStyle = $this->createMock(ScrollingStyleInterface::class);
@@ -45,8 +47,10 @@ class ScrollingStylePluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
+     *
+     * @return void
      */
-    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2()
+    public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
     {
         $container      = $this->createMock(ServiceLocatorInterface::class);
         $scrollingStyle = $this->createMock(ScrollingStyleInterface::class);

--- a/test/ScrollingStylePluginManagerFactoryTest.php
+++ b/test/ScrollingStylePluginManagerFactoryTest.php
@@ -28,8 +28,6 @@ class ScrollingStylePluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
-     *
-     * @return void
      */
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
@@ -47,8 +45,6 @@ class ScrollingStylePluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
-     *
-     * @return void
      */
     public function testFactoryConfiguresPluginManagerUnderServiceManagerV2(): void
     {

--- a/test/TestAsset/TestAdapter.php
+++ b/test/TestAsset/TestAdapter.php
@@ -40,7 +40,6 @@ class TestAdapter implements AdapterInterface
      * @param int $pageNumber
      * @param int $itemCountPerPage
      * @return iterable
-     *
      * @psalm-return ArrayObject<int, int>
      */
     public function getItems($pageNumber, $itemCountPerPage)

--- a/test/TestAsset/TestAdapter.php
+++ b/test/TestAsset/TestAdapter.php
@@ -36,6 +36,12 @@ class TestAdapter implements AdapterInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @param int $pageNumber
+     * @param int $itemCountPerPage
+     * @return iterable
+     *
+     * @psalm-return ArrayObject<int, int>
      */
     public function getItems($pageNumber, $itemCountPerPage)
     {


### PR DESCRIPTION
This patch adds Psalm integration into the QA pipeline, by performing the following steps:

- Adds vimeo/psalm and psalm/plugin-phpunit to the list of dev dependencies.
- Adds a `psalm.xml.dist` file.
- Adds a Psalm baseline file.
- Applies fixes Psalm identified as auto-fixable.

CI pipeline automatically picks up the Psalm configuration and runs checks, so no extra work is required there.