### PR TITLE
fix #37: pass previous exception code instead of null to the second argument of the exception's constructor

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -661,7 +661,7 @@ class Paginator implements Countable, IteratorAggregate
         try {
             return $this->getCurrentItems();
         } catch (Throwable $e) {
-            throw new Exception\RuntimeException('Error producing an iterator', null, $e);
+            throw new Exception\RuntimeException('Error producing an iterator', (int) $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | **yes**
| BC Break      | yes/no
| New Feature   | yes/no
| RFC           | yes/no
| QA            | yes/no

### Description

This PR aims to fix #37. A test is included just in case.