### PR TITLE
Add ArrayCopyInterface to be implemented by DbSelect adapters

### DIFF
--- a/src/Adapter/ArrayCopyInterface.php
+++ b/src/Adapter/ArrayCopyInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Paginator\Adapter;
+
+interface ArrayCopyInterface
+{
+    /**
+     * @internal
+     *
+     * @see https://github.com/laminas/laminas-paginator/issues/3 Reference for creating an internal cache ID
+     *
+     * @todo The next major version should rework the entire caching of a paginator.
+     *
+     * @return array
+     */
+    public function getArrayCopy();
+}

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -12,7 +12,7 @@ use Laminas\Cache\Storage\StorageInterface as CacheStorage;
 use Laminas\Db\ResultSet\AbstractResultSet;
 use Laminas\Filter\FilterInterface;
 use Laminas\Paginator\Adapter\AdapterInterface;
-use Laminas\Paginator\Adapter\DbSelect;
+use Laminas\Paginator\Adapter\ArrayCopyInterface;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
@@ -894,7 +894,7 @@ class Paginator implements Countable, IteratorAggregate, Stringable
     protected function _getCacheInternalId()
     {
         $adapter            = $this->getAdapter();
-        $adapterToSerialize = $adapter instanceof DbSelect
+        $adapterToSerialize = $adapter instanceof ArrayCopyInterface
             ? $adapter->getArrayCopy()
             : $adapter;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The `Paginator::_getCacheInternalId()` check for `Laminas\Paginator\Adapter\DbSelect` instance to access the getArrayCopy() method. That produces a bug if we inject an instance of `Laminas\Paginator\Adapter\LaminasDb\DbSelect`.
The idea here is to check for an Interface instead.
So we can make the Laminas\Paginator\Adapter\LaminasDb\DbSelect implements the interface to completely resolve the bug.
