### PR TITLE
Accept `object` instances implementing `getArrayCopy` when computing cache ID internally, to allow compatibility with more `laminas/laminas-db` versions

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/Adapter/Callback.php">
     <InvalidFunctionCall occurrences="2">
       <code>call_user_func($this-&gt;countCallback)</code>
@@ -167,7 +167,8 @@
     <MixedArrayAccess occurrences="1">
       <code>$page[$itemNumber - 1]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment occurrences="14">
+      <code>$adapterToSerialize</code>
       <code>$adapters</code>
       <code>$cacheIterator</code>
       <code>$cacheIterator</code>
@@ -311,11 +312,6 @@
       <code>$this-&gt;__serialize</code>
     </UndefinedThisPropertyFetch>
   </file>
-  <file src="test/Adapter/ArrayTest.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
   <file src="test/Adapter/CallbackTest.php">
     <MissingClosureParamType occurrences="2">
       <code>$itemCountPerPage</code>
@@ -339,14 +335,6 @@
     <MixedMethodCall occurrences="1">
       <code>getInnerIterator</code>
     </MixedMethodCall>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="test/Adapter/NullFillTest.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/AdapterPluginManagerCompatibilityTest.php">
     <MixedArgument occurrences="3">
@@ -443,34 +431,12 @@
       <code>addPath</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="test/ScrollingStyle/AllTest.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
   <file src="test/ScrollingStyle/ElasticTest.php">
     <MixedArgument occurrences="3">
       <code>$pages-&gt;pagesInRange</code>
       <code>$pages-&gt;pagesInRange</code>
       <code>$pages-&gt;pagesInRange</code>
     </MixedArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="test/ScrollingStyle/JumpingTest.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="test/ScrollingStyle/SlidingTest.php">
-    <PossiblyNullPropertyAssignmentValue occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="test/TestAsset/TestAdapter.php">
     <ParamNameMismatch occurrences="1">

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -12,7 +12,6 @@ use Laminas\Cache\Storage\StorageInterface as CacheStorage;
 use Laminas\Db\ResultSet\AbstractResultSet;
 use Laminas\Filter\FilterInterface;
 use Laminas\Paginator\Adapter\AdapterInterface;
-use Laminas\Paginator\Adapter\DbSelect;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
@@ -894,7 +893,7 @@ class Paginator implements Countable, IteratorAggregate, Stringable
     protected function _getCacheInternalId()
     {
         $adapter            = $this->getAdapter();
-        $adapterToSerialize = $adapter instanceof DbSelect
+        $adapterToSerialize = method_exists($adapter, 'getArrayCopy')
             ? $adapter->getArrayCopy()
             : $adapter;
 

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -919,6 +919,23 @@ class PaginatorTest extends TestCase
         $this->assertNotEquals($firstCacheId, $secondCacheId);
     }
 
+    public function testPaginatorShouldProduceDifferentCacheIdsDependingOnGetArrayCopy(): void
+    {
+        $paginator                    = new Paginator\Paginator(new TestAsset\TestAdapter('foo'));
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        /** @var string $firstCacheId */
+        $firstCacheId = $reflectionGetCacheInternalId->invoke($paginator);
+
+        $paginator                    = new Paginator\Paginator(new TestAsset\TestArrayCopyAdapter('foo'));
+        $reflectionGetCacheInternalId = new ReflectionMethod($paginator, '_getCacheInternalId');
+        $reflectionGetCacheInternalId->setAccessible(true);
+        /** @var string $secondCacheId */
+        $secondCacheId = $reflectionGetCacheInternalId->invoke($paginator);
+
+        $this->assertNotEquals($firstCacheId, $secondCacheId);
+    }
+
     public function testAcceptsComplexAdapters(): void
     {
         $paginator = new Paginator\Paginator(

--- a/test/TestAsset/TestArrayCopyAdapter.php
+++ b/test/TestAsset/TestArrayCopyAdapter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace LaminasTest\Paginator\TestAsset;
+
+class TestArrayCopyAdapter extends TestAdapter
+{
+    public function getArrayCopy()
+    {
+        return [];
+    }
+}

--- a/test/TestAsset/TestArrayCopyAdapter.php
+++ b/test/TestAsset/TestArrayCopyAdapter.php
@@ -1,9 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Paginator\TestAsset;
 
 class TestArrayCopyAdapter extends TestAdapter
 {
+    /**
+     * @return array
+     */
     public function getArrayCopy()
     {
         return [];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The `Paginator::_getCacheInternalId()` check for `Laminas\Paginator\Adapter\DbSelect` instance to access the getArrayCopy() method. That produces a bug if we inject an instance of `Laminas\Paginator\Adapter\LaminasDb\DbSelect`.
The idea here is to check for an Interface instead.
So we can make the Laminas\Paginator\Adapter\LaminasDb\DbSelect implements the interface to completely resolve the bug.
