### PR TITLE
Remove Un-documented Filtering Feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,13 +38,9 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "^3.1.0",
-        "laminas/laminas-filter": "^3.3.0",
         "phpunit/phpunit": "^11.5.43",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.13.1"
-    },
-    "suggest": {
-        "laminas/laminas-filter": "Laminas\\Filter component"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e856b67c9983a64b0f95d9287b822e2d",
+    "content-hash": "d0b544c44299e5fc4da828f385cabd61",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1846,86 +1846,6 @@
                 }
             ],
             "time": "2025-05-13T08:37:04+00:00"
-        },
-        {
-            "name": "laminas/laminas-filter",
-            "version": "3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "e08298df3af44c8b23ada7b9b09c09028a17c39c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/e08298df3af44c8b23ada7b9b09c09028a17c39c",
-                "reference": "e08298df3af44c8b23ada7b9b09c09028a17c39c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-fileinfo": "*",
-                "ext-filter": "*",
-                "ext-iconv": "*",
-                "ext-mbstring": "*",
-                "laminas/laminas-servicemanager": "^4.1.0",
-                "laminas/laminas-stdlib": "^3.19.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1 || ^2",
-                "psr/http-factory": "^1.1",
-                "psr/http-message": "^2.0"
-            },
-            "require-dev": {
-                "ext-bz2": "*",
-                "ext-zip": "*",
-                "ext-zlib": "*",
-                "laminas/laminas-coding-standard": "^3.1.0",
-                "laminas/laminas-diactoros": "^3.8",
-                "pear/archive_tar": "^1.6.0",
-                "pear/pear": "^1.10.16",
-                "phpunit/phpunit": "^11.5.42",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.13.1"
-            },
-            "suggest": {
-                "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",
-                "psr/http-factory-implementation": "psr/http-factory-implementation, for creating file upload instances when consuming PSR-7 in file upload filters"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Filter",
-                    "config-provider": "Laminas\\Filter\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Filter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Programmatically filter and normalize data and files",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "filter",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-filter/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-filter/issues",
-                "rss": "https://github.com/laminas/laminas-filter/releases.atom",
-                "source": "https://github.com/laminas/laminas-filter"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2025-10-14T09:01:57+00:00"
         },
         {
             "name": "league/uri",

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -9,7 +9,6 @@ use ArrayIterator;
 use Countable;
 use Iterator;
 use IteratorAggregate;
-use Laminas\Filter\FilterInterface;
 use Laminas\Paginator\Adapter\AdapterInterface;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
 use Laminas\ServiceManager\ServiceManager;
@@ -113,11 +112,6 @@ final class Paginator implements Countable, IteratorAggregate
      * @var positive-int
      */
     private int $currentPageNumber = 1;
-
-    /**
-     * Result filter
-     */
-    protected FilterInterface|null $filter = null;
 
     /**
      * Number of items per page
@@ -401,28 +395,6 @@ final class Paginator implements Countable, IteratorAggregate
     }
 
     /**
-     * Get the filter
-     *
-     * @return FilterInterface|null
-     */
-    public function getFilter()
-    {
-        return $this->filter;
-    }
-
-    /**
-     * Set a filter chain
-     *
-     * @return Paginator
-     */
-    public function setFilter(FilterInterface $filter)
-    {
-        $this->filter = $filter;
-
-        return $this;
-    }
-
-    /**
      * Returns an item from a page.  The current page is used if there's no
      * page specified.
      *
@@ -525,13 +497,6 @@ final class Paginator implements Countable, IteratorAggregate
         $offset = ($pageNumber - 1) * $this->getItemCountPerPage();
 
         $items = $this->adapter->getItems($offset, $this->getItemCountPerPage());
-
-        $filter = $this->getFilter();
-
-        if ($filter !== null) {
-            /** @psalm-var iterable<TKey, TValue> $items Forced because the filter cannot be annotated */
-            $items = $filter->filter($items);
-        }
 
         if (! $items instanceof Traversable) {
             $items = new ArrayIterator($items);

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -7,7 +7,6 @@ namespace LaminasTest\Paginator;
 use ArrayAccess;
 use ArrayIterator;
 use ArrayObject;
-use Laminas\Filter;
 use Laminas\Paginator;
 use Laminas\Paginator\Adapter;
 use Laminas\Paginator\Adapter\ArrayAdapter;
@@ -27,7 +26,6 @@ use function array_combine;
 use function assert;
 use function count;
 use function is_array;
-use function is_int;
 use function range;
 
 final class PaginatorTest extends TestCase
@@ -389,28 +387,6 @@ final class PaginatorTest extends TestCase
         $expected = '"0":1,"1":2,"2":3,"3":4,"4":5,"5":6,"6":7,"7":8,"8":9,"9":10';
 
         $this->assertStringContainsString($expected, $json);
-    }
-
-    public function testFilter(): void
-    {
-        $callback = function (array $value): array {
-            $data = [];
-
-            foreach ($value as $number) {
-                assert(is_int($number));
-                $data[] = $number * 10;
-            }
-
-            return $data;
-        };
-
-        $filter    = new Filter\Callback($callback);
-        $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter(range(1, 101)));
-        $paginator->setFilter($filter);
-
-        $page = $paginator->getCurrentItems();
-
-        $this->assertEquals(new ArrayIterator(range(10, 100, 10)), $page);
     }
 
     #[Group('Laminas-5785')]


### PR DESCRIPTION
Using a filter to filter out items during pagination would produce unpredictable results such as fewer items per page than the current page size.

Using a filter to iterate over and mutate individual items is a questionable feature at best, and, something highly project-specific for which a dedicated adapter would be a better fit.

None of this is documented and there is no clear use-case for the feature.

Removing it also means we can remove the dependency on `laminas-filter`
