### PR TITLE
Introduce concrete `Pages` type

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -46,10 +46,6 @@
     </UnusedClass>
   </file>
   <file src="src/Paginator.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$pages->pagesInRange]]></code>
-      <code><![CDATA[$pages->pagesInRange]]></code>
-    </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code><![CDATA[is_array($config)]]></code>
       <code><![CDATA[static::$scrollingStyles === null]]></code>

--- a/src/Pages.php
+++ b/src/Pages.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Paginator;
+
+/** @psalm-api None of these properties are un-used */
+final readonly class Pages
+{
+    /**
+     * @param int<0, max> $pageCount
+     * @param int<1, max> $itemCountPerPage
+     * @param int<1, max> $first
+     * @param int<1, max> $current
+     * @param int<1, max> $last
+     * @param int<1, max>|null $previous
+     * @param int<2, max>|null $next
+     * @param array<int, int> $pagesInRange
+     * @param int<1, max> $firstPageInRange
+     * @param int<1, max> $lastPageInRange
+     * @param int<0, max> $currentItemCount
+     * @param int<0, max> $totalItemCount
+     * @param int<0, max> $firstItemNumber
+     * @param int<0, max> $lastItemNumber
+     */
+    public function __construct(
+        public int $pageCount,
+        public int $itemCountPerPage,
+        public int $first,
+        public int $current,
+        public int $last,
+        public int|null $previous,
+        public int|null $next,
+        public array $pagesInRange,
+        public int $firstPageInRange,
+        public int $lastPageInRange,
+        public int $currentItemCount,
+        public int $totalItemCount,
+        public int $firstItemNumber,
+        public int $lastItemNumber,
+    ) {
+    }
+}

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -13,7 +13,6 @@ use Laminas\Paginator\Adapter\AdapterInterface;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
-use stdClass;
 use Throwable;
 use Traversable;
 
@@ -42,22 +41,6 @@ use const JSON_HEX_TAG;
  * @template TKey of array-key
  * @template TValue
  * @implements IteratorAggregate<TKey, TValue>
- * @psalm-type PagesType = object{
- *     pageCount: int,
- *     itemCountPerPage: int,
- *     first: int,
- *     current: int,
- *     last: int,
- *     previous?: int,
- *     next?: int,
- *     pagesInRange: array<int, int>,
- *     firstPageInRange: int,
- *     lastPageInRange: int,
- *     currentItemCount: int,
- *     totalItemCount: int,
- *     firstItemNumber: int,
- *     lastItemNumber: int,
- * }
  */
 final class Paginator implements Countable, IteratorAggregate
 {
@@ -134,13 +117,6 @@ final class Paginator implements Countable, IteratorAggregate
      * @var positive-int
      */
     private int $pageRange;
-
-    /**
-     * Pages
-     *
-     * @var PagesType|null
-     */
-    protected $pages;
 
     /**
      * Set a global config
@@ -553,17 +529,10 @@ final class Paginator implements Countable, IteratorAggregate
 
     /**
      * Returns the page collection.
-     *
-     * @param  string $scrollingStyle Scrolling style
-     * @return PagesType
      */
-    public function getPages($scrollingStyle = null)
+    public function getPages(string|null $scrollingStyle = null): Pages
     {
-        if ($this->pages === null) {
-            $this->pages = $this->createPages($scrollingStyle);
-        }
-
-        return $this->pages;
+        return $this->createPages($scrollingStyle);
     }
 
     /**
@@ -571,7 +540,7 @@ final class Paginator implements Countable, IteratorAggregate
      *
      * @param  int $lowerBound Lower bound of the range
      * @param  int $upperBound Upper bound of the range
-     * @return array<int, int>
+     * @return non-empty-array<int, int>
      */
     public function getPagesInRange($lowerBound, $upperBound)
     {
@@ -583,6 +552,8 @@ final class Paginator implements Countable, IteratorAggregate
         for ($pageNumber = $lowerBound; $pageNumber <= $upperBound; $pageNumber++) {
             $pages[$pageNumber] = $pageNumber;
         }
+
+        assert($pages !== []);
 
         return $pages;
     }
@@ -653,46 +624,59 @@ final class Paginator implements Countable, IteratorAggregate
      * Creates the page collection.
      *
      * @param  string|null $scrollingStyle Scrolling style
-     * @return PagesType
      */
-    private function createPages(string|null $scrollingStyle = null): object
+    private function createPages(string|null $scrollingStyle = null): Pages
     {
         $pageCount         = $this->count();
         $currentPageNumber = $this->getCurrentPageNumber();
 
-        $pages                   = new stdClass();
-        $pages->pageCount        = $pageCount;
-        $pages->itemCountPerPage = $this->getItemCountPerPage();
-        $pages->first            = 1;
-        $pages->current          = $currentPageNumber;
-        $pages->last             = $pageCount;
-
         // Previous and next
+        $previous = $next = null;
         if ($currentPageNumber - 1 > 0) {
-            $pages->previous = $currentPageNumber - 1;
+            $previous = $currentPageNumber - 1;
+            assert($previous >= 1);
         }
 
         if ($currentPageNumber + 1 <= $pageCount) {
-            $pages->next = $currentPageNumber + 1;
+            $next = $currentPageNumber + 1;
         }
 
         // Pages in range
-        $scrollingStyle          = $this->_loadScrollingStyle($scrollingStyle);
-        $pages->pagesInRange     = $scrollingStyle->getPages($this);
-        $pages->firstPageInRange = min($pages->pagesInRange);
-        $pages->lastPageInRange  = max($pages->pagesInRange);
+        $scrollingStyle   = $this->_loadScrollingStyle($scrollingStyle);
+        $pagesInRange     = $scrollingStyle->getPages($this);
+        $firstPageInRange = min($pagesInRange);
+        $lastPageInRange  = max($pagesInRange);
+        assert($firstPageInRange >= 1);
+        assert($lastPageInRange >= 1);
 
         // Item numbers
-        $pages->currentItemCount = $this->getCurrentItemCount();
-        $pages->totalItemCount   = $this->getTotalItemCount();
-        $pages->firstItemNumber  = $pages->totalItemCount
-            ? (($currentPageNumber - 1) * $pages->itemCountPerPage) + 1
+        $currentItemCount = $this->getCurrentItemCount();
+        assert($currentItemCount >= 0);
+        $totalItemCount  = $this->getTotalItemCount();
+        $firstItemNumber = $totalItemCount
+            ? (($currentPageNumber - 1) * $this->itemCountPerPage) + 1
             : 0;
-        $pages->lastItemNumber   = $pages->totalItemCount
-            ? $pages->firstItemNumber + $pages->currentItemCount - 1
+        $lastItemNumber  = $totalItemCount
+            ? $firstItemNumber + $currentItemCount - 1
             : 0;
+        assert($lastItemNumber >= 0);
 
-        return $pages;
+        return new Pages(
+            $pageCount,
+            $this->itemCountPerPage,
+            1,
+            $currentPageNumber,
+            $pageCount === 0 ? 1 : $pageCount,
+            $previous,
+            $next,
+            $pagesInRange,
+            $firstPageInRange,
+            $lastPageInRange,
+            $currentItemCount,
+            $totalItemCount,
+            $firstItemNumber,
+            $lastItemNumber,
+        );
     }
 
     /**

--- a/src/ScrollingStyle/ScrollingStyleInterface.php
+++ b/src/ScrollingStyle/ScrollingStyleInterface.php
@@ -12,7 +12,7 @@ interface ScrollingStyleInterface
      * Returns an array of "local" pages given a page number and range.
      *
      * @param int<1, max>|null $pageRange (Optional) Page range
-     * @return array<int, int>
+     * @return non-empty-array<int, int>
      */
     public function getPages(Paginator $paginator, int|null $pageRange = null): array;
 }

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -105,20 +105,22 @@ final class PaginatorTest extends TestCase
 
     public function testGetsPagesForPageOne(): void
     {
-        $expected                   = new stdClass();
-        $expected->pageCount        = 11;
-        $expected->itemCountPerPage = 10;
-        $expected->first            = 1;
-        $expected->current          = 1;
-        $expected->last             = 11;
-        $expected->next             = 2;
-        $expected->pagesInRange     = array_combine(range(1, 10), range(1, 10));
-        $expected->firstPageInRange = 1;
-        $expected->lastPageInRange  = 10;
-        $expected->currentItemCount = 10;
-        $expected->totalItemCount   = 101;
-        $expected->firstItemNumber  = 1;
-        $expected->lastItemNumber   = 10;
+        $expected = new Paginator\Pages(
+            11,
+            10,
+            1,
+            1,
+            11,
+            null,
+            2,
+            array_combine(range(1, 10), range(1, 10)),
+            1,
+            10,
+            10,
+            101,
+            1,
+            10,
+        );
 
         $actual = $this->paginator->getPages();
 
@@ -127,21 +129,22 @@ final class PaginatorTest extends TestCase
 
     public function testGetsPagesForPageTwo(): void
     {
-        $expected                   = new stdClass();
-        $expected->pageCount        = 11;
-        $expected->itemCountPerPage = 10;
-        $expected->first            = 1;
-        $expected->current          = 2;
-        $expected->last             = 11;
-        $expected->previous         = 1;
-        $expected->next             = 3;
-        $expected->pagesInRange     = array_combine(range(1, 10), range(1, 10));
-        $expected->firstPageInRange = 1;
-        $expected->lastPageInRange  = 10;
-        $expected->currentItemCount = 10;
-        $expected->totalItemCount   = 101;
-        $expected->firstItemNumber  = 11;
-        $expected->lastItemNumber   = 20;
+        $expected = new Paginator\Pages(
+            11,
+            10,
+            1,
+            2,
+            11,
+            1,
+            3,
+            array_combine(range(1, 10), range(1, 10)),
+            1,
+            10,
+            10,
+            101,
+            11,
+            20,
+        );
 
         $this->paginator->setCurrentPageNumber(2);
         $actual = $this->paginator->getPages();
@@ -535,22 +538,23 @@ final class PaginatorTest extends TestCase
         $paginator = new Paginator\Paginator(new Adapter\ArrayAdapter([]));
         $paginator->setCurrentPageNumber(1);
 
-        $expected                   = new stdClass();
-        $expected->pageCount        = 0;
-        $expected->itemCountPerPage = 10;
-        $expected->first            = 1;
-        $expected->current          = 1;
-        $expected->last             = 0;
-        $expected->pagesInRange     = [1 => 1];
-        $expected->firstPageInRange = 1;
-        $expected->lastPageInRange  = 1;
-        $expected->currentItemCount = 0;
-        $expected->totalItemCount   = 0;
-        $expected->firstItemNumber  = 0;
-        $expected->lastItemNumber   = 0;
+        $expected = new Paginator\Pages(
+            0,
+            10,
+            1,
+            1,
+            1,
+            null,
+            null,
+            [1 => 1],
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+        );
 
-        $actual = $paginator->getPages();
-
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expected, $paginator->getPages());
     }
 }


### PR DESCRIPTION
This value object is helpful in view models and was previously an un-documented `stdClass` shape.

This patch solidifies the type to something that users can depend on with well-defined integer boundaries
