### PR TITLE
Remove `Paginator::toJson()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "ext-json": "*",
         "laminas/laminas-servicemanager": "^4.5.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f220cc36fb0cd6333cc638efc4a21ee",
+    "content-hash": "470d49c8b1e4f494be35caafb16a7407",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -5565,8 +5565,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "ext-json": "*"
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,14 +11,6 @@
       <code><![CDATA[AdapterPluginManager]]></code>
     </MethodSignatureMismatch>
   </file>
-  <file src="src/Paginator.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[json_encode($currentItems, $encodeOptions)]]></code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType>
-      <code><![CDATA[string]]></code>
-    </InvalidFalsableReturnType>
-  </file>
   <file src="src/SerializableLimitIterator.php">
     <DirectConstructorCall>
       <code><![CDATA[$this->__construct($data['it'], $data['offset'], $data['count'])]]></code>

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -22,14 +22,8 @@ use function is_numeric;
 use function is_string;
 use function iterator_count;
 use function iterator_to_array;
-use function json_encode;
 use function max;
 use function min;
-
-use const JSON_HEX_AMP;
-use const JSON_HEX_APOS;
-use const JSON_HEX_QUOT;
-use const JSON_HEX_TAG;
 
 /**
  * @template TKey of array-key
@@ -409,17 +403,6 @@ final class Paginator implements Countable, IteratorAggregate
         }
 
         return $pageNumber;
-    }
-
-    /**
-     * Returns the items of the current page as JSON.
-     */
-    public function toJson(): string
-    {
-        $currentItems  = $this->getCurrentItems();
-        $encodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
-
-        return json_encode($currentItems, $encodeOptions);
     }
 
     /**

--- a/test/PaginatorTest.php
+++ b/test/PaginatorTest.php
@@ -341,18 +341,6 @@ final class PaginatorTest extends TestCase
         $this->assertInstanceOf(ArrayObject::class, $paginator->getCurrentItems());
     }
 
-    public function testToJson(): void
-    {
-        $paginator = new Paginator\Paginator(new ArrayAdapter(range(1, 101)));
-        $paginator->setCurrentPageNumber(1);
-
-        $json = $paginator->toJson();
-
-        $expected = '"0":1,"1":2,"2":3,"3":4,"4":5,"5":6,"6":7,"7":8,"8":9,"9":10';
-
-        $this->assertStringContainsString($expected, $json);
-    }
-
     #[Group('Laminas-7207')]
     public function testItemCountPerPageByDefault(): void
     {


### PR DESCRIPTION
We have no idea if the paginated items can be serialised to JSON safely, and it is trivial for users to `json_encode($pager->getCurrentItems())` themselves if they are paginating data that _can_ be encoded.
