### PR TITLE
Re-introduce Caching Features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,14 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "laminas/laminas-servicemanager": "^4.5.0",
+        "psr/cache": "^2.0 || ^3.0",
         "psr/container": "^1 || ^2.0.2"
     },
     "require-dev": {
+        "laminas/laminas-cache": "^4.1",
+        "laminas/laminas-cache-storage-adapter-memory": "^3.1",
         "laminas/laminas-coding-standard": "^3.1.0",
+        "lcobucci/clock": "^3.3",
         "phpunit/phpunit": "^11.5.43",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.13.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "277d13fffc99cf80d2e1fa95b1cf406e",
+    "content-hash": "64d9f771f66e62be20c61888156de2ce",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -256,6 +256,55 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
             "time": "2025-10-21T19:32:17+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/container",
@@ -1795,6 +1844,166 @@
             "time": "2023-02-03T21:26:53+00:00"
         },
         {
+            "name": "laminas/laminas-cache",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache.git",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "reference": "557c34091fdee1791bc16ddc06af583f94caa2dd",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-servicemanager": "^4.1",
+                "laminas/laminas-stdlib": "^3.20",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/clock": "^1.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "webmozart/assert": "^1.11"
+            },
+            "conflict": {
+                "laminas/laminas-serializer": "<3.0",
+                "symfony/console": "<5.1"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cli": "^1.11",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "laminas/laminas-config-aggregator": "^1.17",
+                "laminas/laminas-serializer": "^3.1",
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
+            },
+            "suggest": {
+                "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
+                "laminas/laminas-cache-storage-adapter-blackhole": "Blackhole/Void implementation",
+                "laminas/laminas-cache-storage-adapter-ext-mongodb": "MongoDB implementation",
+                "laminas/laminas-cache-storage-adapter-filesystem": "Filesystem implementation",
+                "laminas/laminas-cache-storage-adapter-memcached": "Memcached implementation",
+                "laminas/laminas-cache-storage-adapter-memory": "Memory implementation",
+                "laminas/laminas-cache-storage-adapter-redis": "Redis implementation",
+                "laminas/laminas-cache-storage-adapter-session": "Session implementation",
+                "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
+                "laminas/laminas-serializer": "Laminas\\Serializer component"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Cache",
+                    "config-provider": "Laminas\\Cache\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Caching implementation with a variety of storage options, as well as codified caching strategies for callbacks, classes, and output",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "cache",
+                "laminas",
+                "psr-16",
+                "psr-6"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-cache/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-cache/issues",
+                "rss": "https://github.com/laminas/laminas-cache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-11-26T08:07:17+00:00"
+        },
+        {
+            "name": "laminas/laminas-cache-storage-adapter-memory",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "reference": "10f0d64c0b3e381a8baaca108803111aa7b110db",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-cache": "^4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "laminas/laminas-cache-storage-implementation": "2.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache-storage-adapter-benchmark": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^4.1",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "lcobucci/clock": "^3.0",
+                "lctrs/psalm-psr-container-plugin": "^1.10",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.24"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\Cache\\Storage\\Adapter\\Memory",
+                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Memory\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cache\\Storage\\Adapter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas cache adapter for memory",
+            "keywords": [
+                "cache",
+                "laminas"
+            ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memory/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-memory/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-memory/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-memory"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2024-11-27T08:14:09+00:00"
+        },
+        {
             "name": "laminas/laminas-coding-standard",
             "version": "3.1.0",
             "source": {
@@ -1846,6 +2055,141 @@
                 }
             ],
             "time": "2025-05-13T08:37:04+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/90b4bd33264629af8e39caf5aa83473ac03aa04c",
+                "reference": "90b4bd33264629af8e39caf5aa83473ac03aa04c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2",
+                "zendframework/zend-eventmanager": "*"
+            },
+            "require-dev": {
+                "amphp/dns": "^2.2",
+                "amphp/socket": "^2.3.1",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-stdlib": "^3.20",
+                "phpbench/phpbench": "^1.3.1",
+                "phpunit/phpunit": "^10.5.58",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "psr/container": "^1.1.2 || ^2.0.2",
+                "sebastian/recursion-context": "^5.0.1",
+                "vimeo/psalm": "^6.13"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2025-10-31T10:29:01+00:00"
+        },
+        {
+            "name": "lcobucci/clock",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/coding-standard": "^11.1.0",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan": "^1.10.25",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^11.3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
+                }
+            ],
+            "description": "Yet another clock abstraction",
+            "support": {
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/3.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-09-24T20:45:14+00:00"
         },
         {
             "name": "league/uri",
@@ -2975,6 +3319,54 @@
             "time": "2025-03-31T18:49:55+00:00"
         },
         {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
             "name": "psr/http-factory",
             "version": "1.1.0",
             "source": {
@@ -3131,6 +3523,57 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/src/Adapter/CachingAdapter.php
+++ b/src/Adapter/CachingAdapter.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Paginator\Adapter;
+
+use DateInterval;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+
+use function sprintf;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ * @implements AdapterInterface<TKey, TValue>
+ */
+final readonly class CachingAdapter implements AdapterInterface
+{
+    /**
+     * @param AdapterInterface<TKey, TValue> $adapter
+     * @param non-empty-string $cacheKeyPrefix
+     */
+    public function __construct(
+        private AdapterInterface $adapter,
+        private string $cacheKeyPrefix,
+        private CacheItemPoolInterface $cache,
+        private DateInterval|null $ttl,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException If the cache prefix is too long or contains unsupported characters.
+     */
+    public function getItems(int $offset, int $itemCountPerPage): iterable
+    {
+        $key  = sprintf('%s-%d-%d', $this->cacheKeyPrefix, $offset, $itemCountPerPage);
+        $item = $this->cache->getItem($key);
+        if ($item->isHit()) {
+            /** @psalm-var iterable<TKey, TValue> */
+            return $item->get();
+        }
+
+        $items = $this->adapter->getItems($offset, $itemCountPerPage);
+        $item->set($items);
+        $item->expiresAfter($this->ttl);
+        $this->cache->save($item);
+
+        return $items;
+    }
+
+    public function count(): int
+    {
+        return $this->adapter->count();
+    }
+}

--- a/src/Adapter/Service/CachingAdapterFactory.php
+++ b/src/Adapter/Service/CachingAdapterFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Paginator\Adapter\Service;
+
+use DateInterval;
+use Laminas\Paginator\Adapter\AdapterInterface;
+use Laminas\Paginator\Adapter\CachingAdapter;
+use Laminas\Paginator\Defaults;
+use Laminas\Paginator\Exception\InvalidArgumentException;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerInterface;
+
+use function get_debug_type;
+use function is_array;
+use function is_int;
+use function is_string;
+use function sprintf;
+
+final readonly class CachingAdapterFactory implements FactoryInterface
+{
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null,
+    ): CachingAdapter {
+        $defaults = $container->get(Defaults::class);
+
+        if (! is_array($options) || $options === []) {
+            throw new InvalidArgumentException('The caching adapter requires non-empty options');
+        }
+
+        $adapter = $options['adapter'] ?? null;
+
+        if (! $adapter instanceof AdapterInterface) {
+            throw new InvalidArgumentException(
+                'An adapter must be supplied under the `adapter` option key',
+            );
+        }
+
+        $cache = $options['cache'] ?? $defaults->defaultCache;
+        if (! $cache instanceof CacheItemPoolInterface) {
+            throw new InvalidArgumentException(
+                'A cache pool was not given under the `cache` option key and a default has not been configured',
+            );
+        }
+
+        /** @psalm-var mixed $ttl */
+        $ttl = $options['ttl'] ?? $defaults->defaultCacheTtl ?? null;
+        if (is_int($ttl) && $ttl > 0) {
+            $ttl = new DateInterval(sprintf('PT%dS', $ttl));
+        }
+
+        if (is_string($ttl)) {
+            $ttl = new DateInterval($ttl);
+        }
+
+        if (! $ttl instanceof DateInterval && $ttl !== null) {
+            throw new InvalidArgumentException(sprintf(
+                'The cache TTL must resolve to a positive date interval. Received "%s"',
+                get_debug_type($ttl),
+            ));
+        }
+
+        $prefix = $options['prefix'] ?? null;
+        if (! is_string($prefix) || $prefix === '') {
+            throw new InvalidArgumentException(
+                'The cache key prefix under the `prefix` option key must be a non-empty string',
+            );
+        }
+
+        return new CachingAdapter(
+            $adapter,
+            $prefix,
+            $cache,
+            $ttl,
+        );
+    }
+}

--- a/src/AdapterPluginManager.php
+++ b/src/AdapterPluginManager.php
@@ -41,10 +41,11 @@ final class AdapterPluginManager extends AbstractPluginManager
             'Iterator' => Adapter\Iterator::class,
         ],
         'factories' => [
-            Adapter\Callback::class     => Adapter\Service\CallbackFactory::class,
-            Adapter\NullFill::class     => Adapter\Service\NullFillFactory::class,
-            Adapter\Iterator::class     => Adapter\Service\IteratorFactory::class,
-            Adapter\ArrayAdapter::class => InvokableFactory::class,
+            Adapter\CachingAdapter::class => Adapter\Service\CachingAdapterFactory::class,
+            Adapter\Callback::class       => Adapter\Service\CallbackFactory::class,
+            Adapter\NullFill::class       => Adapter\Service\NullFillFactory::class,
+            Adapter\Iterator::class       => Adapter\Service\IteratorFactory::class,
+            Adapter\ArrayAdapter::class   => InvokableFactory::class,
         ],
     ];
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Laminas\Paginator;
 
+use DateInterval;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
 use Laminas\ServiceManager\ServiceManager;
 
 /**
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  * @psalm-type PaginatorDefaults = array{
- *     itemCountPerPage: int<1, max>,
- *     pageRange: int<1, max>,
- *     scrollingStyle: string|ScrollingStyleInterface,
+ *     itemCountPerPage?: int<1, max>,
+ *     pageRange?: int<1, max>,
+ *     scrollingStyle?: string|ScrollingStyleInterface,
+ *     defaultCache?: string|null,
+ *     defaultCacheTTL?: string|int|DateInterval|null,
  * }
  */
 final readonly class ConfigProvider
@@ -34,6 +37,19 @@ final readonly class ConfigProvider
                 'itemCountPerPage' => 10,
                 'pageRange'        => 10,
                 'scrollingStyle'   => 'Sliding',
+                /**
+                 * This value should be a string representing a cache pool that can be retrieved from the DI container
+                 * if you want to be able to easily create caching paginators.
+                 */
+                'defaultCache' => null,
+                /**
+                 * This value should be a string that can be understood by DateInterval, for example, a 30 minute TTL
+                 * would be "PT30M". Null is also acceptable and means that paginated items will not expire until
+                 * manually flushed.
+                 *
+                 * @see https://www.php.net/manual/dateinterval.construct.php
+                 */
+                'defaultCacheTTL' => null,
             ],
             'paginators'   => [],
         ];

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Paginator;
 
+use DateInterval;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * @internal
@@ -22,6 +24,8 @@ final readonly class Defaults
         public int $itemCountPerPage,
         public int $pageRange,
         public ScrollingStyleInterface $scrollingStyle,
+        public CacheItemPoolInterface|null $defaultCache,
+        public DateInterval|null $defaultCacheTtl,
     ) {
     }
 }

--- a/src/DefaultsFactory.php
+++ b/src/DefaultsFactory.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace Laminas\Paginator;
 
 use ArrayAccess;
+use DateInterval;
 use Laminas\Paginator\Exception\ExceptionInterface;
 use Laminas\Paginator\Exception\RuntimeException;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleFactory;
 use Laminas\Paginator\ScrollingStyle\ScrollingStyleInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Container\ContainerInterface;
 
 use function assert;
+use function get_debug_type;
 use function is_array;
 use function is_int;
 use function is_string;
@@ -75,10 +78,48 @@ final readonly class DefaultsFactory implements FactoryInterface
             $style = $instance;
         }
 
+        $cache = $options['defaultCache'] ?? null;
+        if ($cache !== null && (! is_string($cache) || $cache === '')) {
+            throw new RuntimeException(
+                'The default cache should be a non-empty string when set',
+            );
+        }
+
+        if ($cache !== null) {
+            /** @psalm-var mixed $cache */
+            $cache = $container->get($cache);
+            if (! $cache instanceof CacheItemPoolInterface) {
+                throw new RuntimeException(sprintf(
+                    'The default cache should resolve to an instance of "%s", Received "%s"',
+                    CacheItemPoolInterface::class,
+                    get_debug_type($cache),
+                ));
+            }
+        }
+
+        /** @var mixed $defaultTtl */
+        $defaultTtl = $options['defaultCacheTTL'] ?? null;
+        if (is_int($defaultTtl)) {
+            $defaultTtl = new DateInterval(sprintf('PT%dS', $defaultTtl));
+        }
+
+        if (is_string($defaultTtl) && $defaultTtl !== '') {
+            $defaultTtl = new DateInterval($defaultTtl);
+        }
+
+        if (! $defaultTtl instanceof DateInterval && $defaultTtl !== null) {
+            throw new RuntimeException(sprintf(
+                'The default TTL must be configured as a date interval string, integer or null. Received %s',
+                get_debug_type($defaultTtl),
+            ));
+        }
+
         return new Defaults(
             $itemCount,
             $range,
             $style,
+            $cache,
+            $defaultTtl,
         );
     }
 }

--- a/src/PaginatorFactory.php
+++ b/src/PaginatorFactory.php
@@ -6,6 +6,8 @@ namespace Laminas\Paginator;
 
 use Laminas\Paginator\Adapter\AdapterInterface;
 use Laminas\Paginator\Adapter\ArrayAdapter;
+use Laminas\Paginator\Adapter\CachingAdapter;
+use Laminas\Paginator\Exception\RuntimeException;
 
 use function assert;
 use function is_array;
@@ -34,6 +36,43 @@ final readonly class PaginatorFactory
             $this->defaults->itemCountPerPage,
             $this->defaults->pageRange,
             $this->defaults->scrollingStyle,
+        );
+    }
+
+    /**
+     * Generate a paginator with the given adapter wrapped in a caching adapter.
+     *
+     * You must configure the default cache or an exception will be thrown. It is also advisable to configure a default
+     * TTL, as it's unlikely that you'll want paginated items cached forever.
+     *
+     * The cache key prefix should be unique to the data set you are paginating. Cache key collisions are not considered
+     * so you are responsible for providing something that will prevent the cache from returning incorrect data across
+     * multiple paginators.
+     *
+     * @template TKey of array-key
+     * @template TValue
+     * @param AdapterInterface<TKey, TValue> $adapter
+     * @param non-empty-string $cacheKeyPrefix
+     * @return Paginator<TKey, TValue>
+     * @throws RuntimeException If a default cache has not been configured.
+     */
+    public function withCachingAdapter(AdapterInterface $adapter, string $cacheKeyPrefix): Paginator
+    {
+        if ($this->defaults->defaultCache === null) {
+            throw new RuntimeException(
+                'You cannot generate caching paginators without configuring the cache service '
+                . 'under `paginators.defaultCache`',
+            );
+        }
+
+        return $this->buildAdapter(
+            CachingAdapter::class,
+            [
+                'adapter' => $adapter,
+                'prefix'  => $cacheKeyPrefix,
+                'cache'   => $this->defaults->defaultCache,
+                'ttl'     => $this->defaults->defaultCacheTtl,
+            ],
         );
     }
 

--- a/test/Adapter/CachingAdapterTest.php
+++ b/test/Adapter/CachingAdapterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Paginator\Adapter;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
+use Laminas\Cache\Storage\Adapter\Memory;
+use Laminas\Paginator\Adapter\ArrayAdapter;
+use Laminas\Paginator\Adapter\CachingAdapter;
+use Lcobucci\Clock\FrozenClock;
+use PHPUnit\Framework\TestCase;
+
+use function range;
+use function sleep;
+use function sprintf;
+
+final class CachingAdapterTest extends TestCase
+{
+    private CacheItemPoolDecorator $cache;
+    private FrozenClock $clock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clock = new FrozenClock(new DateTimeImmutable('2025-01-01 10:00:00', new DateTimeZone('UTC')));
+        $this->cache = new CacheItemPoolDecorator(new Memory(), $this->clock);
+    }
+
+    public function testCountIsCorrect(): void
+    {
+        $arrayAdapter = new ArrayAdapter(range(1, 100));
+        $adapter      = new CachingAdapter(
+            $arrayAdapter,
+            'foo',
+            $this->cache,
+            null,
+        );
+
+        self::assertSame($arrayAdapter->count(), $adapter->count());
+    }
+
+    public function testItemsWillBeCached(): void
+    {
+        $key     = sprintf('%s-%d-%d', 'foo', 0, 10);
+        $adapter = new CachingAdapter(
+            new ArrayAdapter(range(1, 100)),
+            'foo',
+            $this->cache,
+            new DateInterval('PT1S'),
+        );
+
+        $item = $this->cache->getItem($key);
+        self::assertFalse($item->isHit());
+
+        $items = $adapter->getItems(0, 10);
+        self::assertSame(range(1, 10), $items);
+
+        $item = $this->cache->getItem($key);
+        self::assertTrue($item->isHit());
+        self::assertSame(range(1, 10), $item->get());
+        self::assertSame(range(1, 10), $adapter->getItems(0, 10));
+    }
+
+    public function testItemsWillHaveTheExpectedTtl(): void
+    {
+        $key     = sprintf('%s-%d-%d', 'bar', 0, 10);
+        $adapter = new CachingAdapter(
+            new ArrayAdapter(range(1, 100)),
+            'bar',
+            $this->cache,
+            new DateInterval('PT1S'),
+        );
+
+        $adapter->getItems(0, 10);
+
+        // Freezing the clock does not work unfortunately…
+
+        sleep(1);
+
+        $item = $this->cache->getItem($key);
+        self::assertFalse($item->isHit());
+    }
+
+    public function testInvalidResultsAreReturnedWithIdenticalCachePrefixes(): void
+    {
+        $adapter = new CachingAdapter(
+            new ArrayAdapter(range(1, 100)),
+            'baz',
+            $this->cache,
+            new DateInterval('PT10M'),
+        );
+
+        $adapter2 = new CachingAdapter(
+            new ArrayAdapter(range(101, 200)),
+            'baz',
+            $this->cache,
+            new DateInterval('PT10M'),
+        );
+
+        $items = $adapter->getItems(0, 10);
+        self::assertSame(range(1, 10), $items);
+
+        $cached = $adapter2->getItems(0, 10);
+
+        self::assertSame(range(1, 10), $cached);
+    }
+}

--- a/test/Adapter/Service/CachingAdapterFactoryTest.php
+++ b/test/Adapter/Service/CachingAdapterFactoryTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Paginator\Adapter\Service;
+
+use DateInterval;
+use Exception;
+use Laminas\Paginator\Adapter\ArrayAdapter;
+use Laminas\Paginator\Adapter\CachingAdapter;
+use Laminas\Paginator\Adapter\Service\CachingAdapterFactory;
+use Laminas\Paginator\ConfigProvider;
+use Laminas\Paginator\Exception\InvalidArgumentException;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use ReflectionProperty;
+use Throwable;
+
+use function array_replace_recursive;
+
+final class CachingAdapterFactoryTest extends TestCase
+{
+    private function containerWithConfig(array $config = []): ServiceManager
+    {
+        $config = array_replace_recursive(
+            (new ConfigProvider())->__invoke(),
+            $config,
+        );
+
+        /** @psalm-suppress MixedArrayAssignment Life is too short */
+        $config['dependencies']['services']['config'] = $config;
+
+        /** @psalm-suppress MixedArgument */
+        return new ServiceManager($config['dependencies']);
+    }
+
+    /** @return list<array{0: null|array}> */
+    public static function missingOptions(): array
+    {
+        return [
+            [null],
+            [[]],
+        ];
+    }
+
+    #[DataProvider('missingOptions')]
+    public function testOptionsMustBeSpecified(array|null $options): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = new CachingAdapterFactory();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The caching adapter requires non-empty options');
+
+        $factory->__invoke($container, 'foo', $options);
+    }
+
+    public function testAnAdapterToWrapIsARequiredOption(): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = new CachingAdapterFactory();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An adapter must be supplied under the `adapter` option key');
+
+        $factory->__invoke($container, 'foo', ['adapter' => null]);
+    }
+
+    public function testACacheMustBeConfigured(): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = new CachingAdapterFactory();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'A cache pool was not given under the `cache` option key and a default has not been configured',
+        );
+
+        $factory->__invoke($container, 'foo', ['adapter' => new ArrayAdapter([])]);
+    }
+
+    /** @return list<array{0: mixed}> */
+    public static function invalidPrefixes(): array
+    {
+        return [
+            [''],
+            [null],
+            [10],
+        ];
+    }
+
+    #[DataProvider('invalidPrefixes')]
+    public function testANonEmptyPrefixMustBeConfigured(mixed $prefix): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = new CachingAdapterFactory();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The cache key prefix under the `prefix` option key must be a non-empty string',
+        );
+
+        $factory->__invoke($container, 'foo', [
+            'adapter' => new ArrayAdapter([]),
+            'cache'   => $this->createMock(CacheItemPoolInterface::class),
+            'prefix'  => $prefix,
+        ]);
+    }
+
+    /** @return list<array{0: mixed, 1: class-string<Throwable>}> */
+    public static function invalidCacheTtl(): array
+    {
+        return [
+            ['', Exception::class],
+            ['Kermit', Exception::class],
+            [-10, InvalidArgumentException::class],
+            [(object) [], InvalidArgumentException::class],
+        ];
+    }
+
+    /** @param class-string<Throwable> $expectException */
+    #[DataProvider('invalidCacheTtl')]
+    public function testInvalidTtlValues(mixed $ttl, string $expectException): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = new CachingAdapterFactory();
+        $this->expectException($expectException);
+
+        $factory->__invoke($container, 'foo', [
+            'adapter' => new ArrayAdapter([]),
+            'cache'   => $this->createMock(CacheItemPoolInterface::class),
+            'prefix'  => 'foo',
+            'ttl'     => $ttl,
+        ]);
+    }
+
+    /** @return list<array{0: mixed, 1: DateInterval|null}> */
+    public static function validTtlValues(): array
+    {
+        return [
+            [null, null],
+            [new DateInterval('PT10S'), new DateInterval('PT10S')],
+            ['PT10S', new DateInterval('PT10S')],
+            [10, new DateInterval('PT10S')],
+        ];
+    }
+
+    #[DataProvider('validTtlValues')]
+    public function testValidTtl(mixed $ttl, DateInterval|null $expect): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = new CachingAdapterFactory();
+
+        $adapter = $factory->__invoke($container, 'foo', [
+            'adapter' => new ArrayAdapter([]),
+            'cache'   => $this->createMock(CacheItemPoolInterface::class),
+            'prefix'  => 'foo',
+            'ttl'     => $ttl,
+        ]);
+
+        $this->assertTtlMatches($adapter, $expect);
+    }
+
+    private function assertTtlMatches(CachingAdapter $adapter, DateInterval|null $expect): void
+    {
+        $reflectionProperty = new ReflectionProperty($adapter, 'ttl');
+        /** @psalm-var mixed $value */
+        $value = $reflectionProperty->getValue($adapter);
+
+        self::assertEquals($expect, $value);
+    }
+}

--- a/test/DefaultsFactoryTest.php
+++ b/test/DefaultsFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Paginator;
 
+use DateInterval;
 use Laminas\Paginator\ConfigProvider;
 use Laminas\Paginator\DefaultsFactory;
 use Laminas\Paginator\Exception\RuntimeException;
@@ -13,6 +14,8 @@ use Laminas\Paginator\ScrollingStyle\Sliding;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
 use function array_replace_recursive;
@@ -162,5 +165,120 @@ final class DefaultsFactoryTest extends TestCase
 
         $this->expectException(NotFoundExceptionInterface::class);
         $factory($container, 'bar');
+    }
+
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidDefaultCacheOptions(): array
+    {
+        return [
+            'Empty String' => [''],
+            'Object'       => [(object) []],
+        ];
+    }
+
+    #[DataProvider('invalidDefaultCacheOptions')]
+    public function testWhenSetTheDefaultCacheOptionMustBeAString(mixed $option): void
+    {
+        $container = $this->containerWithConfig([
+            'paginator' => [
+                'defaultCache' => $option,
+            ],
+        ]);
+        $factory   = new DefaultsFactory();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The default cache should be a non-empty string when set');
+
+        $factory($container, 'bar');
+    }
+
+    public function testTheDefaultCacheWillBeResolved(): void
+    {
+        $cache     = $this->createMock(CacheItemPoolInterface::class);
+        $container = $this->containerWithConfig([
+            'paginator'    => [
+                'defaultCache' => 'Kermit',
+            ],
+            'dependencies' => [
+                'services' => [
+                    'Kermit' => $cache,
+                ],
+            ],
+        ]);
+        $factory   = new DefaultsFactory();
+        $defaults  = $factory($container, 'bar');
+
+        self::assertSame($cache, $defaults->defaultCache);
+    }
+
+    public function testTheCacheMustResolveToTheCorrectInstanceType(): void
+    {
+        $container = $this->containerWithConfig([
+            'paginator'    => [
+                'defaultCache' => 'Kermit',
+            ],
+            'dependencies' => [
+                'services' => [
+                    'Kermit' => 'Not a cache',
+                ],
+            ],
+        ]);
+        $factory   = new DefaultsFactory();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The default cache should resolve to an instance of');
+
+        $factory($container, 'bar');
+    }
+
+    /** @return list<array{0: mixed}> */
+    public static function invalidCacheTllOptions(): array
+    {
+        return [
+            [''],
+            [(object) []],
+        ];
+    }
+
+    #[DataProvider('invalidCacheTllOptions')]
+    public function testInvalidCacheTtlOptionsCauseExceptions(mixed $ttl): void
+    {
+        $container = $this->containerWithConfig([
+            'paginator' => [
+                'defaultCacheTTL' => $ttl,
+            ],
+        ]);
+        $factory   = new DefaultsFactory();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The default TTL must be configured as a date interval string, integer or null');
+
+        $factory($container, 'bar');
+    }
+
+    /** @return list<array{0: mixed, 1: DateInterval}> */
+    public static function validCacheTllOptions(): array
+    {
+        return [
+            [10, new DateInterval('PT10S')],
+            [new DateInterval('PT10M'), new DateInterval('PT10M')],
+            ['PT15M', new DateInterval('PT15M')],
+        ];
+    }
+
+    /**
+     * @throws ContainerExceptionInterface
+     */
+    #[DataProvider('validCacheTllOptions')]
+    public function testValidCacheTtlOptionsYieldExpectedValue(mixed $ttl, DateInterval $expect): void
+    {
+        $container = $this->containerWithConfig([
+            'paginator' => [
+                'defaultCacheTTL' => $ttl,
+            ],
+        ]);
+        $factory   = new DefaultsFactory();
+        $defaults  = $factory($container, 'bar');
+        self::assertEquals($expect, $defaults->defaultCacheTtl);
     }
 }

--- a/test/PaginatorFactoryTest.php
+++ b/test/PaginatorFactoryTest.php
@@ -6,12 +6,15 @@ namespace LaminasTest\Paginator;
 
 use ArrayIterator;
 use Laminas\Paginator\Adapter\ArrayAdapter;
+use Laminas\Paginator\Adapter\CachingAdapter;
 use Laminas\Paginator\ConfigProvider;
+use Laminas\Paginator\Exception\RuntimeException;
 use Laminas\Paginator\PaginatorFactoryFactory;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use LaminasTest\Paginator\TestAsset\TestArrayAggregate;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
 
 use function array_replace_recursive;
 use function iterator_to_array;
@@ -166,5 +169,42 @@ final class PaginatorFactoryTest extends TestCase
         ], $pager->getPages()->pagesInRange);
 
         self::assertEquals([13, 14, 15], iterator_to_array($pager->getCurrentItems()));
+    }
+
+    public function testCachingAdaptersCannotBeBuiltWhenThereIsNoDefaultCache(): void
+    {
+        $container = $this->containerWithConfig();
+        $factory   = (new PaginatorFactoryFactory())->__invoke($container, 'foo');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'You cannot generate caching paginators without configuring the '
+            . 'cache service under `paginators.defaultCache`',
+        );
+
+        $factory->withCachingAdapter(new ArrayAdapter([]), 'foo');
+    }
+
+    public function testACachingAdapterCanBeSuccessfullyBuilt(): void
+    {
+        $cache     = $this->createMock(CacheItemPoolInterface::class);
+        $container = $this->containerWithConfig([
+            'paginator'    => [
+                'defaultCache' => 'Muppets',
+            ],
+            'dependencies' => [
+                'services' => [
+                    'Muppets' => $cache,
+                ],
+            ],
+        ]);
+        $factory   = (new PaginatorFactoryFactory())->__invoke($container, 'foo');
+
+        $paginator = $factory->withCachingAdapter(
+            new ArrayAdapter([]),
+            'foo',
+        );
+
+        self::assertInstanceOf(CachingAdapter::class, $paginator->getAdapter());
     }
 }


### PR DESCRIPTION
Instead of building caching into the Paginator, adds a `CachingAdapter` that can be used to decorate any other adapter type.

Users can either manually instantiate caching adapters, or configure defaults via DI and use the provided factories.

We should probably get #89 merged first so that I can update the docs for the feature
