### PR TITLE
Updates and refines v3 documentation structure and content

### DIFF
--- a/docs/book/v3/advanced.md
+++ b/docs/book/v3/advanced.md
@@ -1,4 +1,4 @@
-# Advanced usage
+# Advanced Usage
 
 ## Using the Paginator Adapter Plugin Manager
 
@@ -21,7 +21,7 @@ $arrayAdapter = $pluginManager->build(Adapter\ArrayAdapter::class, [$arrayOfItem
 $iteratorAdapter = $pluginManager->build(Adapter\Iterator::class, [$iterator]);
 ```
 
-## Custom data source adapters
+## Custom Data Source Adapters
 
 At some point you may run across a data type that is not covered by the packaged adapters.
 In this case, you will need to write your own.

--- a/docs/book/v3/usage.md
+++ b/docs/book/v3/usage.md
@@ -1,6 +1,6 @@
-# Usage
+# Basic Usage
 
-## Paginating data collections
+## Paginating Data Collections
 
 In order to paginate items into pages, `Laminas\Paginator` must have a generic way of accessing that data.
 For that reason, all data access takes place through data source adapters.
@@ -284,19 +284,73 @@ The paginator keeps track of its current position and provides a number of metho
 
 ```php
 assert($pager instanceof Laminas\Paginator\Paginator);
+```
 
+### Current Page Number
+
+```php
 printf("The current page number is %d\n", $pager->getCurrentPageNumber());
+```
+
+### Current Items Per Page
+
+```php
 printf("The current page contains %d items\n", $pager->getCurrentItemCount());
+```
+
+### Total Items
+
+```php
 printf("In total there are %d items\n", $pager->getTotalItemCount());
+```
 
+### Page Results
+
+The `getPages()` method returns a `Laminas\Paginator\Pages` immutable value object containing information about the current page and the total number of pages:
+
+```php
 $pagesResult = $pager->getPages();
+```
 
+#### First Page Number
+
+```php
 printf("The first page number is %d\n", $pagesResult->first);
+```
+
+#### First Page Number in Range
+
+```php
 printf("The first page number in range is %d\n", $pagesResult->firstPageInRange);
+```
+
+#### Last Page Number
+
+```php
 printf("The last page number is %d\n", $pagesResult->last);
+```
+
+#### Last Page Number in Range
+
+```php
 printf("The last page number in range is %d\n", $pagesResult->lastPageInRange);
+```
+
+#### Next Page Number
+
+```php
 printf("The next page number is %s\n", $pagesResult->next ?? 'NONE');
+```
+
+#### Previous Page Number
+
+```php
 printf("The previous page number is %s\n", $pagesResult->previous ?? 'NONE');
+```
+
+#### Total Number of Pages
+
+```php
 printf("The total number of pages is %d\n", $pagesResult->pageCount);
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,10 +5,10 @@ nav:
     - v3:
         - Introduction: v3/intro.md
         - Installation: v3/installation.md
-        - Usage: v3/usage.md
+        - "Basic Usage": v3/usage.md
         - Configuration: v3/configuration.md
         - "Advanced Usage": v3/advanced.md
-        - "Caching Paged Result Sets": v3/caching.md
+        - "Caching Paginator Pages": v3/caching.md
         - 'Application Integration':
             - 'Stand-Alone': v3/application-integration/stand-alone.md
         - 'Migration':
@@ -28,7 +28,6 @@ extra:
     project: Components
     installation:
         config_provider_class: 'Laminas\Paginator\ConfigProvider'
-        module_class: 'Laminas\Paginator\Module'
     current_version: v3
     versions:
         - v3


### PR DESCRIPTION
- Adjusts titles for consistency ("Usage" → "Basic Usage", "Advanced usage" → "Advanced Usage").
- Adds improved examples and sections in `Basic Usage`.
- Refines terminology ("Caching Paged Result Sets" → "Caching Paginator Pages").
- Removes unnecessary config entry in `mkdocs.yml`.
